### PR TITLE
Modern Fortran 2008 serial interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(ChIMES_Calculator
 	VERSION 1.0
 	DESCRIPTION "Utilities to compute ChIMES interactions"
 	LANGUAGES CXX C Fortran)
-    
+
 
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
 
@@ -26,6 +26,7 @@ add_executable(CPP-interface
     ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/chimesFF.cpp
 )
 
+
 # Define properties for the executable target
 
 target_include_directories(CPP-interface PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/examples/cpp)
@@ -34,9 +35,9 @@ target_include_directories(CPP-interface PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/chi
 target_compile_features   (CPP-interface PRIVATE cxx_std_11)
 target_compile_options    (CPP-interface PRIVATE -O3)
 
-IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	install(TARGETS CPP-interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/cpp/ OPTIONAL)
-ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 
 ############################################################
@@ -59,9 +60,9 @@ target_include_directories(C_wrapper-direct_interface PRIVATE ${CMAKE_CURRENT_SO
 target_compile_features   (C_wrapper-direct_interface PRIVATE cxx_std_11)
 target_compile_options    (C_wrapper-direct_interface PRIVATE -O3)
 
-IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	install(TARGETS C_wrapper-direct_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/c/ OPTIONAL)
-ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 
 ############################################################
@@ -86,7 +87,7 @@ target_include_directories(C_wrapper-serial_interface PRIVATE ${CMAKE_CURRENT_SO
 target_compile_features   (C_wrapper-serial_interface PRIVATE cxx_std_11)
 target_compile_options    (C_wrapper-serial_interface PRIVATE -O3)
 
-IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	install(TARGETS C_wrapper-serial_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/c/ OPTIONAL)
 ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
@@ -114,7 +115,7 @@ target_compile_features   (lib-C_wrapper-direct_interface PUBLIC cxx_std_11)
 target_compile_options    (lib-C_wrapper-direct_interface PUBLIC -O3)
 target_compile_options    (lib-C_wrapper-direct_interface PUBLIC -fPIC)
 
-IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	install(TARGETS lib-C_wrapper-direct_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/python/ OPTIONAL)
 ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
@@ -127,7 +128,7 @@ ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 ADD_LIBRARY(lib-C_wrapper-serial_interface MODULE
     ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/api/wrapper-C.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/src/serial_chimes_interface.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/chimesFF.cpp    
+    ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/chimesFF.cpp
 )
 
 set_target_properties(lib-C_wrapper-serial_interface PROPERTIES PREFIX "") # Prevent CMake from prepending "lib" to libwrapper-C.so
@@ -142,7 +143,7 @@ target_compile_options    (lib-C_wrapper-serial_interface PUBLIC -O3)
 target_compile_options    (lib-C_wrapper-serial_interface PUBLIC -fPIC)
 
 #install(TARGETS lib-C_wrapper-serial_interface DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/examples/python/)
-IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	install(TARGETS lib-C_wrapper-serial_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/python/ OPTIONAL)
 ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
@@ -170,7 +171,7 @@ target_compile_options    (fortran_wrapper-direct_interface PRIVATE -O3)
 target_compile_options    (fortran_wrapper-direct_interface PRIVATE -fPIC)
 target_compile_options    (fortran_wrapper-direct_interface PRIVATE -std=f2003)
 
-IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	install(TARGETS fortran_wrapper-direct_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/fortran/ OPTIONAL)
 ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
@@ -199,8 +200,33 @@ target_compile_options    (fortran_wrapper-serial_interface PRIVATE -O3)
 target_compile_options    (fortran_wrapper-serial_interface PRIVATE -fPIC)
 target_compile_options    (fortran_wrapper-serial_interface PRIVATE -std=f2003)
 
-IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+
+IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 	install(TARGETS fortran_wrapper-serial_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/fortran/ OPTIONAL)
 ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
+# Define an executable target
 
+add_executable(fortran08_wrapper-serial_interface
+    ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/examples/fortran08/main.F90
+    ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/api/wrapper-F.F90
+    ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/api/wrapper-F08.F90
+    ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/api/wrapper-C.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/src/serial_chimes_interface.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/chimesFF.cpp
+)
+
+# Define properties for the executable target
+
+target_include_directories(fortran08_wrapper-serial_interface PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/examples/fortran08/)
+target_include_directories(fortran08_wrapper-serial_interface PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/api/)
+target_include_directories(fortran08_wrapper-serial_interface PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/src/)
+target_include_directories(fortran08_wrapper-serial_interface PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/)
+target_compile_features   (fortran08_wrapper-serial_interface PRIVATE cxx_std_11)
+target_compile_options    (fortran08_wrapper-serial_interface PRIVATE -O3)
+target_compile_options    (fortran08_wrapper-serial_interface PRIVATE -fPIC)
+target_compile_options    (fortran08_wrapper-serial_interface PRIVATE -std=f2008)
+
+IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+	install(TARGETS fortran08_wrapper-serial_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/fortran08/ OPTIONAL)
+ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/serial_interface/api/wrapper-C.cpp
+++ b/serial_interface/api/wrapper-C.cpp
@@ -1,7 +1,7 @@
-/* 
+/*
     ChIMES Calculator
     Copyright (C) 2020 Rebecca K. Lindsey, Nir Goldman, and Laurence E. Fried
-	Contributing Author:  Nir Goldman (2020) 
+	Contributing Author:  Nir Goldman (2020)
 */
 
 #include<vector>
@@ -28,24 +28,21 @@ void set_chimes () {
 void init_chimes (char *param_file, int *rank) {
   chimes_ptr->init_chimesFF(param_file, *rank);
 }
-void calculate_chimes_fromF90(int *natom, double *xc, double *yc, double *zc, char *atom_types[], double ca[3], double cb[3], double cc[3], double *energy, double fx[], double fy[], double fz[], double stress[9])
-{
-    calculate_chimes(*natom, xc, yc, zc, atom_types, ca, cb, cc, energy, fx, fy, fz, stress);
-}
+
 void calculate_chimes(int natom, double *xc, double *yc, double *zc, char *atom_types[], double ca[3], double cb[3], double cc[3], double *energy, double fx[], double fy[], double fz[], double stress[9])
 {
   vector<double>    x_vec(natom);
   vector<double>    y_vec(natom);
   vector<double>    z_vec(natom);
-  
-  vector<vector<double> > force_vec; 
+
+  vector<vector<double> > force_vec;
   force_vec.resize(natom, vector<double>(3,0.0));
-  
-  
+
+
   vector<string> atom_types_vec;
   atom_types_vec.resize(natom);
-  
-  
+
+
   for (int i = 0; i < natom; i++) {
     x_vec[i] = xc[i];
     y_vec[i] = yc[i];

--- a/serial_interface/api/wrapper-C.h
+++ b/serial_interface/api/wrapper-C.h
@@ -1,18 +1,16 @@
-/* 
+/*
     ChIMES Calculator
     Copyright (C) 2020 Rebecca K. Lindsey, Nir Goldman, and Laurence E. Fried
-	Contributing Author:  Nir Goldman (2020) 
+	Contributing Author:  Nir Goldman (2020)
 */
 
 #ifdef __cplusplus
 extern "C" {
-#endif 
+#endif
 
 void set_chimes();
 void init_chimes(char *param_file, int *rank);
-void calculate_chimes(int natom, double *xc, double *yc, double *zc, char *atom_types[], double ca[3], double cb[3], double cc[3], double *energy, double fx[], double fy[], double fz[], double stress[9]); 
-void calculate_chimes_fromF90(int *natom, double *xc, double *yc, double *zc, char *atom_types[], double ca[3], double cb[3], double cc[3], double *energy, double fx[], double fy[], double fz[], double stress[9]);
+void calculate_chimes(int natom, double *xc, double *yc, double *zc, char *atom_types[], double ca[3], double cb[3], double cc[3], double *energy, double fx[], double fy[], double fz[], double stress[9]);
 #ifdef __cplusplus
 }
 #endif
-

--- a/serial_interface/api/wrapper-F.F90
+++ b/serial_interface/api/wrapper-F.F90
@@ -1,43 +1,48 @@
 ! ChIMES Calculator
 ! Copyright (C) 2020 Rebecca K. Lindsey, Nir Goldman, and Laurence E. Fried
-! Contributing Author:  Nir Goldman (2020) 
+! Contributing Author:  Nir Goldman (2020)
 
-      module wrapper
-      use, intrinsic :: ISO_C_binding
-      implicit none
-      interface 
-        subroutine f_calculate_chimes (natom, xc, yc, zc, cptr, ca,  &
-      &            cb, cc, energy, fx, fy, fz, stress)  &
-      &            bind (C, name='calculate_chimes_fromF90')
-          use, intrinsic :: ISO_C_binding, only : C_char, C_ptr, C_int, C_double
-          type(c_ptr), dimension(*)  :: cptr(natom)
-          integer(C_int) :: natom  
-          real(C_double) :: xc(natom), yc(natom), zc(natom)
-          real(C_double) :: fx(natom), fy(natom), fz(natom)
-          character(C_char), dimension(80) :: c_atom(natom)
-          real(C_double) :: ca(3), cb(3), cc(3) 
-          real(C_double) :: energy
-          real(C_double) :: stress(9)
-        end subroutine f_calculate_chimes
-        subroutine f_set_chimes() bind (C, name='set_chimes')
-        end subroutine f_set_chimes
-        subroutine f_init_chimes(param_file, rank) & 
-      &            bind (C, name='init_chimes') 
-          import C_int, C_char
-          integer(C_int), intent(in) :: rank
-          character (kind=C_char), dimension(*) :: param_file
-        end subroutine f_init_chimes
-      end interface
-      contains
-      function string2Cstring (string) result (C_string)
-        use, intrinsic :: ISO_C_binding, only : C_char, C_NULL_CHAR
-        character (len=*), intent(in) :: string
-        character (len=1, kind=C_char) :: C_string (len_trim(string)+1)
-        integer :: i, n
-        n = len_trim (string)
-        forall (i = 1:n)
-           C_string(i) = string(i:i)
-        end forall
-        C_string(n+1) = C_NULL_CHAR
-      end function string2Cstring
-      end module
+module chimes_serial
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_int, c_double, c_char, c_null_char
+  implicit none
+
+  private
+  public :: f_init_chimes, f_set_chimes, f_calculate_chimes, string_to_cstring
+
+  interface
+
+    subroutine f_init_chimes(param_file, rank) bind (C, name='init_chimes')
+      import :: c_int, c_char
+      character (kind=c_char), dimension(*) :: param_file
+      integer(c_int), intent(in) :: rank
+    end subroutine f_init_chimes
+
+    subroutine f_set_chimes() bind(C, name='set_chimes')
+    end subroutine f_set_chimes
+
+    subroutine f_calculate_chimes (natom, xc, yc, zc, atom_types, ca, cb, cc, energy,&
+        & fx, fy, fz, stress) bind(C, name='calculate_chimes')
+      import :: c_char, c_ptr, c_int, c_double
+      integer(c_int), value :: natom
+      real(c_double), intent(in) :: xc(*), yc(*), zc(*)
+      type(c_ptr), intent(in) :: atom_types(*)
+      real(c_double), intent(in) :: ca(*), cb(*), cc(*)
+      real(c_double), intent(inout) :: energy
+      real(c_double), intent(inout) :: fx(*), fy(*), fz(*)
+      real(c_double), intent(inout) :: stress(*)
+    end subroutine f_calculate_chimes
+
+  end interface
+
+contains
+
+  ! Converts a Fortran string to a C-string
+  pure function string_to_cstring(string) result(cstring)
+    character(len=*), intent(in) :: string
+    character(len=(len_trim(string) + len(c_null_char)), kind=c_char) :: cstring
+
+    cstring = trim(string) // c_null_char
+
+  end function string_to_cstring
+
+end module chimes_serial

--- a/serial_interface/api/wrapper-F08.F90
+++ b/serial_interface/api/wrapper-F08.F90
@@ -1,0 +1,160 @@
+! ChIMES Calculator
+! Copyright (C) 2020 Rebecca K. Lindsey, Nir Goldman, and Laurence E. Fried
+! Contributing Author:  Nir Goldman (2020)
+! Modern Fortran (Fortran 2003) interface: Bálint Aradi (2021)
+
+!> Provides simplified (a.k.a. serial) ChIMES interface using modern Fortran.
+!>
+!> Note: Currently the simplified ChIMES interface only allows the creation of one ChIMES instance
+!> without the possibility of destroying that instance. Therefore, the Fortran interface only
+!> allows the creation of one ChIMES-calculator.
+!>
+module chimes_serial08
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_double, c_char, c_loc
+  use chimes_serial, only : f_init_chimes, f_set_chimes, f_calculate_chimes, string_to_cstring
+  implicit none
+
+  private
+  public :: ChimesCalc, ChimesCalc_init
+
+  !> Default precision for reals
+  integer, parameter :: dp = c_double
+
+  !> Internal variable counting nr. of active calculator instances (only 1 allowed)
+  integer :: active_instances_ = 0
+
+
+  !> Chimes calculator
+  type :: ChimesCalc
+    private
+
+    !> Whether the calculator is active
+    logical :: is_active_ = .false.
+
+    !> C representation of the atom type names.
+    character(len=:), pointer :: c_atom_types_(:) => null()
+
+    !> C pointers referencing the atom type names
+    type(c_ptr), allocatable :: c_atom_type_ptrs_(:)
+
+  contains
+
+    procedure :: set_atom_types => ChimesCalc_set_atom_types
+    procedure :: calculate => ChimesCalc_calculate
+    final :: ChimesCalc_final
+
+  end type ChimesCalc
+
+
+contains
+
+  !> Initializes ChIMES calculator
+  subroutine ChimesCalc_init(this, paramfile, nrank)
+
+    !> Initialized instance on exit.
+    type(ChimesCalc), intent(inout) :: this
+
+    !> Name of the parameter file to use for the initialization
+    character(*), intent(in) :: paramfile
+
+    !> Rank parameter (?)
+    integer, intent(in) :: nrank
+
+    if (this%is_active_) then
+      error stop "This ChimesCalc instance has already been initialized"
+    end if
+    if (active_instances_ /= 0) then
+      error stop "Only one chimes_calc instance is allowed"
+    end if
+    this%is_active_ = .true.
+    active_instances_ = 1
+
+    call f_set_chimes()
+    call f_init_chimes(string_to_cstring(paramfile), nrank)
+
+  end subroutine ChimesCalc_init
+
+
+  !> Destroys ChIMES calculator
+  subroutine ChimesCalc_final(this)
+    type(ChimesCalc), intent(inout) :: this
+
+    this%is_active_ = .false.
+    ! As the C-interface does not offer finalization, we do not allow for a new ChIMES instance
+    ! even if the exising one had been destroyed.
+    !active_instances_ = 0
+    if (associated(this%c_atom_types_)) then
+      deallocate(this%c_atom_types_)
+    end if
+
+  end subroutine ChimesCalc_final
+
+
+  !> Sets the atom types (needs the type name of each atom)
+  !>
+  !> This has to be called in order to set up the atom types, before calculate() can be invoked.
+  !> It must be called only once, unless the atom types change (e.g. atoms are reordered).
+  !>
+  subroutine ChimesCalc_set_atom_types(this, atom_types)
+
+    !> Instance.
+    class(ChimesCalc), intent(inout) :: this
+
+    !> Type name of each atom. Shape: [nr_of_atoms]
+    character(*), intent(in) :: atom_types(:)
+
+    integer :: natom, iat
+
+    if (associated(this%c_atom_types_)) then
+      deallocate(this%c_atom_types_)
+    end if
+    if (allocated(this%c_atom_type_ptrs_)) then
+      deallocate(this%c_atom_type_ptrs_)
+    end if
+
+    natom = size(atom_types)
+    allocate(character(len=(len(atom_types) + 1)) :: this%c_atom_types_(natom))
+    allocate(this%c_atom_type_ptrs_(natom))
+    do iat = 1, natom
+      this%c_atom_types_(iat) = string_to_cstring(trim(atom_types(iat)))
+      this%c_atom_type_ptrs_(iat) = c_loc(this%c_atom_types_(iat))
+    end do
+
+  end subroutine ChimesCalc_set_atom_types
+
+
+  !> Calculates (adds) various ChIMES contributions
+  !>
+  !> Note: You have to call set_atom_types() once before you can call this method.
+  !>
+  subroutine ChimesCalc_calculate(this, coords, latvecs, energy, forces, stress)
+
+    !> Instance.
+    class(ChimesCalc), intent(inout) :: this
+
+    !> Coordinates of the atoms. Shape: [3, nr_of_atoms]
+    real(dp), intent(in) :: coords(:,:)
+
+    !> Lattice vectors. Shape: [3, 3], first index runs over x,y,z, second over lattice vectors.
+    real(dp), intent(in) :: latvecs(:,:)
+
+    !> Variable which should be increased by the ChIMES energy.
+    real(dp), intent(inout) :: energy
+
+    !> Forces, which ChIMES contribution should be added to. Shape: [3, nr_of_atoms].
+    real(dp), intent(inout) :: forces(:,:)
+
+    !> Stress tensor, which the ChIMES contribution should be added to. Shape: [3, 3].
+    real(dp), intent(inout), contiguous, target :: stress(:,:)
+
+    real(dp), pointer :: stress_1d(:)
+
+    stress_1d(1 : size(stress)) => stress
+    call f_calculate_chimes(size(this%c_atom_types_), coords(1, :), coords(2, :), coords(3, :),&
+        & this%c_atom_type_ptrs_, latvecs(:, 1), latvecs(:, 2), latvecs(:, 3), energy,&
+        & forces(1, :), forces(2, :), forces(3, :), stress_1d)
+
+  end subroutine ChimesCalc_calculate
+
+
+end module chimes_serial08

--- a/serial_interface/examples/fortran/main.F90
+++ b/serial_interface/examples/fortran/main.F90
@@ -1,19 +1,17 @@
 ! ChIMES Calculator
 ! Copyright (C) 2020 Rebecca K. Lindsey, Nir Goldman, and Laurence E. Fried
-! Contributing Author:  Nir Goldman (2020) 
+! Contributing Author:  Nir Goldman (2020)
 
       program test_F_api
-      use wrapper
+      use chimes_serial
       use, intrinsic :: ISO_C_binding
       implicit none
-      integer io_num, stat
+      integer io_num
       double precision, parameter :: GPa = 6.9479 ! convert kcal/mol.A^3 to GPa
-      character(C_char), dimension(80) :: c_file
-      character(C_char), dimension(80) :: dummy_var
-      character(80) :: coord_file, param_file
-      CHARACTER ( len = 100 ) :: wq_char
-      integer :: i, j, k, l, natom, ns
-      real(C_double) ::   lx, ly, lz
+      character(kind=c_char, len=1024) :: c_file
+      character(1024) :: coord_file, param_file
+      CHARACTER (1024) :: wq_char
+      integer :: i, natom, ns
       real(C_double) :: stress(9)
       real(C_double) :: energy
       real(C_double) :: ca(3), cb(3), cc(3)
@@ -21,7 +19,6 @@
       character(len=10), allocatable, target :: atom_type(:), c_atom(:)
       character(len=2) :: atom
       TYPE(C_PTR), allocatable, dimension(10) :: stringPtr(:)
-      integer lenstr
 
       io_num = command_argument_count()
       if (io_num .lt. 2) then
@@ -29,12 +26,12 @@
         print*,"Exiting code.\n"
         STOP
       endif
-      
+
       call GET_COMMAND_ARGUMENT(1, wq_char)
       param_file = trim(wq_char)
       call GET_COMMAND_ARGUMENT(2, wq_char)
-      coord_file = trim(wq_char)  
-      
+      coord_file = trim(wq_char)
+
       open (unit=10, status='old', file=coord_file)
       read(10,*)natom
       read(10,*)ca(1),ca(2),ca(3),cb(1),cb(2),cb(3),cc(1),cc(2),cc(3)
@@ -62,7 +59,7 @@
       ! initialize system energy
       energy = 0d0
       call f_set_chimes()
-      c_file = string2Cstring(param_file)
+      c_file = string_to_cstring(param_file)
       call f_init_chimes(c_file,  0) ! last '0' is the rank of the process
       stress(:) = 0d0
       do ns = 1, natom
@@ -87,9 +84,9 @@
          print '(F15.6)',fy(i)
          print '(F15.6)',fz(i)
       enddo
-      
+
 #if DEBUG==1
-      
+
       open (unit = 20, status = 'replace', file='debug.dat')
       write(20,'(F15.6)') energy
       write(20,'(F15.6)') stress(1)*GPa
@@ -104,6 +101,6 @@
          write(20,'(E15.6)') fz(i)
       enddo
       close(20)
-#endif 
+#endif
 
       end program

--- a/serial_interface/examples/fortran08/Makefile
+++ b/serial_interface/examples/fortran08/Makefile
@@ -1,0 +1,78 @@
+CXX     = g++ -O3 -std=c++11 -fPIC
+FCC     = gfortran -O3 -fPIC -std=f2003 -cpp # last flag allows processing of C-style pre-processor directives
+
+DEBUG   = 0
+
+#CCFLAGS = -fPIC -O3 -std=c++11 
+#FFLAGS  = -O3 -fPIC
+#COMM1   = wrapper-F.o main.o 
+
+F_LOC = $(realpath .)
+
+CHIMESFF_LOC=$(F_LOC)/../../../chimesFF/src
+CHIMESFF_SRC=$(CHIMESFF_LOC)/chimesFF.cpp
+CHIMESFF_HDR=$(CHIMESFF_LOC)/chimesFF.h
+
+chimesFF.o : $(CHIMESFF_SRC)
+	$(CXX) -c $(CHIMESFF_SRC) -I $(CHIMESFF_LOC)
+
+SERIAL_LOC=$(F_LOC)/../../src
+SERIAL_SRC=$(SERIAL_LOC)/serial_chimes_interface.cpp
+SERIAL_HDR=$(SERIAL_LOC)/serial_chimes_interface.h
+
+serial_chimes_interface.o : $(SERIAL_SRC) 
+	$(CXX) -c $(SERIAL_SRC) -I $(SERIAL_LOC) -I $(CHIMESFF_LOC) 
+	
+WRAPPERC_LOC=$(F_LOC)/../../api
+WRAPPERC_SRC=$(WRAPPERC_LOC)/wrapper-C.cpp
+WRAPPERC_HDR=$(WRAPPERC_LOC)/wrapper-h.cpp
+
+wrapper-C.o : $(WRAPPERC_SRC) 
+	$(CXX) -c $(WRAPPERC_SRC) -I $(WRAPPERC_LOC) -I $(SERIAL_LOC) -I $(CHIMESFF_LOC)	
+
+WRAPPERF_LOC=$(F_LOC)/../../api
+WRAPPERF_SRC=$(WRAPPERF_LOC)/wrapper-F.F90
+
+wrapper-F.o chimes.mod : $(WRAPPERF_SRC) 
+	$(FCC) -c $(WRAPPERF_SRC) -o wrapper-F.o
+
+main.o : main.F90
+	$(FCC) -c main.F90 -o main.o  -DDEBUG=${DEBUG}
+
+
+LINKS = chimesFF.o serial_chimes_interface.o  wrapper-C.o wrapper-F.o main.o
+
+# Rudimentary OS detection
+UNAME := $(shell uname)
+
+ifeq (${UNAME},Darwin)
+	FCC += -lc++
+else
+	FCC += -stdc++
+endif
+
+test-F: $(LINKS)
+	$(FCC) $(LINKS) -o fortran_wrapper-serial_interface
+lib : chimesFF.o serial_chimes_interface.o wrapper-C.o
+	ar rcs libchimes.a chimesFF.o serial_chimes_interface.o wrapper-C.o 
+
+clean: 
+	rm -f *.o *.mod
+	
+clean-all:
+	make clean
+	rm -f fortran_wrapper-serial_interface
+	rm -f libchimes.a
+	
+all:
+	make chimesFF.o
+	make serial_chimes_interface.o 
+	make wrapper-C.o
+	make wrapper-F.o chimes.mod
+	make main.o
+	make test-F
+	make lib
+	make clean
+
+
+

--- a/serial_interface/examples/fortran08/main.F90
+++ b/serial_interface/examples/fortran08/main.F90
@@ -1,0 +1,84 @@
+! ChIMES Calculator
+! Copyright (C) 2020 Rebecca K. Lindsey, Nir Goldman, and Laurence E. Fried
+! Contributing Author:  Nir Goldman (2020)
+! Contributing Author: Bálint Aradi (2021)
+
+program test_F08_api
+  use chimes_serial08, only : ChimesCalc, ChimesCalc_init
+  implicit none
+
+  integer, parameter :: dp = kind(1.0d0)
+  real(dp), parameter :: GPa = 6.9479 ! convert kcal/mol.A^3 to GPa
+
+  type(ChimesCalc) :: chimes
+  integer :: io_num, fd
+  character(1024) :: coord_file, param_file
+  integer :: iatom, natom
+  real(dp) :: latvecs(3, 3), stress(3, 3)
+  real(dp) :: energy
+  real(dp), allocatable :: coords(:,:), forces(:,:)
+  character(len=10), allocatable :: atom_types(:)
+
+
+  io_num = command_argument_count()
+  if (io_num < 2) then
+    print *, "To run: ./test_F08.x <parameter file> <xyz config. file>"
+    print *, "Exiting code."
+    error stop
+  end if
+
+  call get_command_argument(1, param_file)
+  call get_command_argument(2, coord_file)
+
+  open (newunit=fd, status='old', file=coord_file)
+  read(fd, *) natom
+  read(fd, *) latvecs(:, 1), latvecs(:, 2), latvecs(:, 3)
+
+  allocate(forces(3, natom))
+  allocate(atom_types(natom))
+  allocate(coords(3, natom))
+
+  read(fd, *) (atom_types(iatom), coords(:, iatom), iatom = 1, natom)
+  close(fd)
+
+  energy = 0.0_dp
+  forces(:,:) = 0.0_dp
+  stress(:,:) = 0.0_dp
+
+  ! Initialize ChiMES calculator
+  call ChimesCalc_init(chimes, trim(param_file), 0)
+
+  ! Set that atom types. You need this call only once (unless atom types change)
+  call chimes%set_atom_types(atom_types)
+
+  ! Get contributions. This call can be done several times with various coords/latvecs.
+  call chimes%calculate(coords, latvecs, energy, forces, stress)
+
+  print *, "Success!"
+  print '(A,1X, F0.6)', "Energy (kcal/mol)", energy
+  print *, "Stress tensors (GPa)"
+  print '(A,1X, F15.6)', "s_xx: ", stress(1, 1) * GPa
+  print '(A,1X, F15.6)', "s_yy: ", stress(2, 2) * GPa
+  print '(A,1X, F15.6)', "s_zz: ", stress(3, 3) * GPa
+  print '(A,1X, F15.6)', "s_xy: ", stress(1, 2) * GPa
+  print '(A,1X, F15.6)', "s_xz: ", stress(1, 3) * GPa
+  print '(A,1X, F15.6)', "s_yz: ", stress(2, 3) * GPa
+  print *, "Forces (kcal/mol)"
+  print '(F15.6)', forces
+
+#if DEBUG==1
+
+  open (newunit=fd, status='replace', file='debug.dat')
+  write(fd, '(F15.6)') energy
+  write(fd, '(F15.6)') stress(1, 1) * GPa
+  write(fd, '(F15.6)') stress(2, 2) * GPa
+  write(fd, '(F15.6)') stress(3, 3) * GPa
+  write(fd, '(F15.6)') stress(1, 2) * GPa
+  write(fd, '(F15.6)') stress(1, 3) * GPa
+  write(fd, '(F15.6)') stress(2, 3) * GPa
+  write(fd, '(E15.6)') forces
+  close(fd)
+
+#endif
+
+end program


### PR DESCRIPTION
* [x] Provide Chimes calculator object
* [x] Ensure uniqueness of the calculator
* [x] Deal with Fortran types only, no C-types in the interface
* [x] Cleaned also old Fortran interface a bit
* [x] Test with DFTB+ for integration

It also fixes the CMake compilation problem with the Fortran example at main...