### PR TITLE
Increase cmake minimum to enable cache variable override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 ############################################################
 # General settings


### PR DESCRIPTION
Would it be possible, to increase the minimum CMake version to 3.13? That would allow a seamless overriding of the cache variables of the ChIMES build system with normal CMake variables, when the ChIMES build is invoked on the fly in a CMake based project (e.g. DFTB+).