### PR TITLE
Workaround to make serial interface GFortran 7 & 8 compatible

### DIFF
--- a/chimesFF/api/chimescalc_F.f90
+++ b/chimesFF/api/chimescalc_F.f90
@@ -11,6 +11,7 @@
        & type2, type3, type4, f4b, stress, sys_ener) &
        & bind (C, name='chimes_compute_4b_props_fromf90')
           import C_double, C_char, C_ptr
+          implicit none
           real(C_double), intent(in) :: dr_4b(6), dist_4b(3,6)
           real(C_double) :: stress(9)
           real(C_double) :: f4b(3,4)
@@ -25,6 +26,7 @@
        & type2, type3, f3b, stress, sys_ener) &
        & bind (C, name='chimes_compute_3b_props_fromf90')
           import C_double, C_char, C_ptr
+          implicit none
           real(C_double), intent(in) :: dr_3b(3), dist_3b(3,3)
           real(C_double) :: stress(9)
           real(C_double) :: f3b(3,3)
@@ -38,6 +40,7 @@
        & type2, f2b, stress, sys_ener) &
        & bind (C, name='chimes_compute_2b_props_fromf90')
           import C_double, C_char, C_ptr
+          implicit none
           real(C_double), intent(in) :: rij, dr(3)
           real(C_double) :: stress(9)
           real(C_double) :: f2b(2,3)
@@ -51,48 +54,56 @@
 
         subroutine f_init_chimes(rank) bind (C, name='init_chimes')
           import C_int
+          implicit none
           integer(C_int), intent(in) :: rank
         end subroutine f_init_chimes
 
         subroutine f_chimes_read_params(param_file) &
       &   bind (C, name='chimes_read_params')
           import C_char
+          implicit none
           character (kind=C_char), dimension(*) :: param_file
         end subroutine f_chimes_read_params
 
         function f_get_chimes_2b_order () result (order2b) &
           bind (C, name='get_chimes_2b_order')
           import :: C_int
+          implicit none
           integer (C_int) :: order2b
         end function f_get_chimes_2b_order
 
         function f_get_chimes_3b_order () result (order3b) &
           bind (C, name='get_chimes_3b_order')
           import :: C_int
+          implicit none
           integer (C_int) :: order3b
         end function f_get_chimes_3b_order
 
         function f_get_chimes_4b_order () result (order4b) &
           bind (C, name='get_chimes_4b_order')
           import :: C_int
+          implicit none
           integer (C_int) :: order4b
         end function f_get_chimes_4b_order
 
         function f_get_chimes_max_2b_cutoff () result (rcut_2b) &
           bind (C, name='get_chimes_max_2b_cutoff')
           import :: C_double
+          implicit none
           real(C_double) :: rcut_2b
         end function f_get_chimes_max_2b_cutoff
 
         function f_get_chimes_max_3b_cutoff () result (rcut_3b) &
           bind (C, name='get_chimes_max_3b_cutoff')
           import :: C_double
+          implicit none
           real(C_double) :: rcut_3b
         end function f_get_chimes_max_3b_cutoff
 
         function f_get_chimes_max_4b_cutoff () result (rcut_4b) &
           bind (C, name='get_chimes_max_4b_cutoff')
           import :: C_double
+          implicit none
           real(C_double) :: rcut_4b
         end function f_get_chimes_max_4b_cutoff
 
@@ -104,9 +115,9 @@
         character (len=1, kind=C_char) :: C_string (len_trim(string)+1)
         integer :: i, n
         n = len_trim (string)
-        forall (i = 1:n)
+        do i = 1, n
            C_string(i) = string(i:i)
-        end forall
+        end do
         C_string(n+1) = C_NULL_CHAR
       end function string2Cstring
       end module chimescalc

--- a/serial_interface/api/chimescalc_serial_F.f90
+++ b/serial_interface/api/chimescalc_serial_F.f90
@@ -12,8 +12,9 @@
       &            cb, cc, energy, fx, fy, fz, stress)  &
       &            bind (C, name='calculate_chimes')
           use, intrinsic :: ISO_C_binding, only : C_char, C_ptr, C_int, C_double
-          type(c_ptr), dimension(*)  :: cptr(natom)
+          implicit none
           integer(C_int), value :: natom
+          type(c_ptr), dimension(*)  :: cptr(natom)
           real(C_double) :: xc(natom), yc(natom), zc(natom)
           real(C_double) :: fx(natom), fy(natom), fz(natom)
           character(C_char), dimension(80) :: c_atom(natom)
@@ -25,6 +26,7 @@
         subroutine f_set_chimes(small) bind &
       &            (C, name='set_chimes_serial')
           use, intrinsic :: ISO_C_binding, only : C_ptr, C_int
+          implicit none
           integer(C_int), value :: small
         end subroutine f_set_chimes
 
@@ -45,9 +47,9 @@
         character (len=1, kind=C_char) :: C_string (len_trim(string)+1)
         integer :: i, n
         n = len_trim (string)
-        forall (i = 1:n)
+        do i = 1, n
            C_string(i) = string(i:i)
-        end forall
+        end do
         C_string(n+1) = C_NULL_CHAR
       end function string2Cstring
 

--- a/serial_interface/api/chimescalc_serial_F08.f90
+++ b/serial_interface/api/chimescalc_serial_F08.f90
@@ -10,7 +10,7 @@
 !> allows the creation of one ChIMES-calculator.
 !>
 module chimescalc_serial08
-  use, intrinsic :: iso_c_binding, only : c_ptr, c_double, c_char, c_loc
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_double, c_char, c_loc, c_null_char
   use chimescalc_serial, only : f_init_chimes, f_set_chimes, f_calculate_chimes, string2Cstring
   implicit none
 
@@ -23,6 +23,11 @@ module chimescalc_serial08
   !> Internal variable counting nr. of active calculator instances (only 1 allowed)
   integer :: active_instances_ = 0
 
+  ! Workaround: gfortran 7, gfortran 8
+  ! Deferred length character arrays are not handled correclty, leading to trashed memory
+  ! Therefore a fixed character length array is used for the species names, instead
+  integer, parameter :: species_name_length = 20
+
 
   !> Chimes calculator
   type :: ChimesCalc
@@ -32,7 +37,7 @@ module chimescalc_serial08
     logical :: is_active_ = .false.
 
     !> C representation of the atom type names.
-    character(len=:), pointer :: c_atom_types_(:) => null()
+    character(len=species_name_length+1), pointer :: c_atom_types_(:) => null()
 
     !> C pointers referencing the atom type names
     type(c_ptr), allocatable :: c_atom_type_ptrs_(:)
@@ -114,10 +119,13 @@ contains
     end if
 
     natom = size(atom_types)
-    allocate(character(len=(len(atom_types) + 1)) :: this%c_atom_types_(natom))
+    !allocate(character(len=(len(atom_types) + 1)) :: this%c_atom_types_(natom))
+    allocate(this%c_atom_types_(natom))
     allocate(this%c_atom_type_ptrs_(natom))
     do iat = 1, natom
-      this%c_atom_types_(iat) = trim(atom_types(iat))//char(0)
+      !this%c_atom_types_(iat) = trim(atom_types(iat)) // c_null_char
+      this%c_atom_types_(iat) = &
+          & atom_types(iat)(1 : min(len_trim(atom_types(iat)), species_name_length)) // c_null_char
       this%c_atom_type_ptrs_(iat) = c_loc(this%c_atom_types_(iat))
     end do
 


### PR DESCRIPTION
* Contains a workaround for a compiler bug in GFortran 7 & 8.
* Adds some `implicit none` statements to interfaces to make them more robust, and reorders argument definition order to comply to standard.