### PR TITLE
Compiler flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
       run: |
         CMAKE_PREFIX_PATH=${ROOTFOLDER}/_install cmake -B _build_integtest -G Ninja ${ROOTFOLDER}/serial_interface/examples/fortran08
         cmake --build _build_integtest
-        ./_build_integtest/test_chimescalc ${ROOTFOLDER}/serial_interface/tests/force_fields/test_params.CHON.txt serial_interface/tests/configurations/CHON.testfile.000.xyz
+        LD_LIBRARY_PATH=${ROOTFOLDER}/_install/lib ./_build_integtest/test_chimescalc ${ROOTFOLDER}/serial_interface/tests/force_fields/test_params.CHON.txt serial_interface/tests/configurations/CHON.testfile.000.xyz | grep "Energy (kcal/mol) -7.83714"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,11 @@ include(GNUInstallDirs)
 set(INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME_LOWER}")
 set(INSTALL_MODULEDIR "${INSTALL_INCLUDEDIR}/modfiles")
 
+include(cmake/ChimesCalc.cmake)
 include(config.cmake)
 
-if(WITH_FORTRAN_API OR WITH_FORTRAN08_API)
-    enable_language(Fortran)
-endif()
-
+chimescalc_setup_build_type()
+chimescalc_setup_compiler_flags()
 
 # Check whether libm is needed to provide the round() function in C
 include(CheckLibraryExists)
@@ -203,7 +202,6 @@ if(WITH_FORTRAN_API OR WITH_FORTRAN08_API)
 
     add_executable(fortran_wrapper-direct_interface chimesFF/examples/fortran/main.F90)
     target_link_libraries     (fortran_wrapper-direct_interface ChimesCalc_Fortran)
-    target_compile_options    (fortran_wrapper-direct_interface PRIVATE -std=f2003)
     target_compile_definitions(fortran_wrapper-direct_interface PRIVATE "DEBUG=${DEBUG}")
 
     if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -214,7 +212,6 @@ if(WITH_FORTRAN_API OR WITH_FORTRAN08_API)
 
     add_executable(fortran_wrapper-serial_interface serial_interface/examples/fortran/main.F90)
     target_link_libraries     (fortran_wrapper-serial_interface ChimesCalc_Fortran)
-    target_compile_options    (fortran_wrapper-serial_interface PRIVATE -std=f2003)
     target_compile_definitions(fortran_wrapper-serial_interface PRIVATE "DEBUG=${DEBUG}")
 
     if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -227,7 +224,6 @@ if(WITH_FORTRAN_API OR WITH_FORTRAN08_API)
         add_executable(fortran08_wrapper-serial_interface
             serial_interface/examples/fortran08/main.F90)
         target_link_libraries	  (fortran08_wrapper-serial_interface ChimesCalc_Fortran)
-	      target_compile_options    (fortran08_wrapper-serial_interface PRIVATE -std=f2008)
 	      target_compile_definitions(fortran08_wrapper-serial_interface PRIVATE "DEBUG=${DEBUG}")
 
 	      if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ project(ChimesCalc
     DESCRIPTION "ChIMES calculator: Utilities to compute ChIMES interactions"
 	LANGUAGES CXX C
 )
+
 string(TOLOWER "${PROJECT_NAME}" PROJECT_NAME_LOWER)
 
 include(GNUInstallDirs)
@@ -62,15 +63,107 @@ install(TARGETS ChimesCalc
 )
 
 
+############################################################
+# Executables for C/C++
+############################################################
+
+add_executable(CPP-interface ${c-sources} serial_interface/examples/cpp/main.cpp)
+target_link_libraries(CPP-interface ChimesCalc)
+target_compile_features   (CPP-interface PUBLIC cxx_std_11)
+target_compile_options    (CPP-interface PUBLIC -O3)
+target_compile_definitions(CPP-interface PRIVATE "DEBUG=${DEBUG}")
+
+
+IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+	install(TARGETS CPP-interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/cpp/ OPTIONAL)
+ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+
+add_executable(C_wrapper-direct_interface ${c-sources} chimesFF/examples/c/main.c)
+target_link_libraries     (C_wrapper-direct_interface ChimesCalc)
+target_compile_features   (C_wrapper-direct_interface PRIVATE cxx_std_11)
+target_compile_options    (C_wrapper-direct_interface PRIVATE -O3)
+target_compile_definitions(C_wrapper-direct_interface PRIVATE "DEBUG=${DEBUG}")
+
+
+IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+	install(TARGETS C_wrapper-direct_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/c/ OPTIONAL)
+ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+
+
+add_executable(C_wrapper-serial_interface ${c-sources} serial_interface/examples/c/main.c)
+target_link_libraries     (C_wrapper-serial_interface ChimesCalc)
+target_include_directories(C_wrapper-serial_interface PRIVATE serial_interface/api/)
+target_compile_features   (C_wrapper-serial_interface PRIVATE cxx_std_11)
+target_compile_options    (C_wrapper-serial_interface PRIVATE -O3)
+target_compile_definitions(C_wrapper-serial_interface PRIVATE "DEBUG=${DEBUG}")
+
+IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+	install(TARGETS C_wrapper-serial_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/c/ OPTIONAL)
+ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+
+
+############################################################
+# Executables/libraries for Python 
+############################################################
+
+
+# Shared: .dylib
+# Static: .a
+# Module: .so
+
+add_library(lib-C_wrapper-direct_interface MODULE
+    ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/api/chimescalc_C.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/chimesFF.cpp
+)
+
+set_target_properties     (lib-C_wrapper-direct_interface PROPERTIES PREFIX "") # Prevent CMake from prepending "lib" to libwrapper-C.so
+set_target_properties     (lib-C_wrapper-direct_interface PROPERTIES LINKER_LANGUAGE CXX)  # Tell it which language to use
+target_include_directories(lib-C_wrapper-direct_interface PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/)
+target_include_directories(lib-C_wrapper-direct_interface PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/api/)
+target_compile_features   (lib-C_wrapper-direct_interface PUBLIC cxx_std_11)
+target_compile_options    (lib-C_wrapper-direct_interface PUBLIC -O3)
+target_compile_options    (lib-C_wrapper-direct_interface PUBLIC -fPIC)
+
+IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+	install(TARGETS lib-C_wrapper-direct_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/python/ OPTIONAL)
+ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+
+
+add_library(lib-C_wrapper-serial_interface MODULE  
+    ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/api/chimescalc_serial_C.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/src/serial_chimes_interface.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/chimesFF.cpp
+)
+
+set_target_properties     (lib-C_wrapper-serial_interface PROPERTIES PREFIX "") # Prevent CMake from prepending "lib" to libwrapper-C.so
+set_target_properties     (lib-C_wrapper-serial_interface PROPERTIES LINKER_LANGUAGE CXX)  # Tell it which language to use
+target_include_directories(lib-C_wrapper-serial_interface PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/api/)
+target_include_directories(lib-C_wrapper-serial_interface PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/src/)
+target_include_directories(lib-C_wrapper-serial_interface PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/)
+target_compile_features   (lib-C_wrapper-serial_interface PUBLIC cxx_std_11)
+target_compile_options    (lib-C_wrapper-serial_interface PUBLIC -O3)
+target_compile_options    (lib-C_wrapper-serial_interface PUBLIC -fPIC)
+
+#install(TARGETS lib-C_wrapper-serial_interface DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/examples/python/)
+IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+	install(TARGETS lib-C_wrapper-serial_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/python/ OPTIONAL)
+ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+
+
+
 ###############################################################################
 # Fortran library (separate library as it needs Fortran runtime to be linked)
 ###############################################################################
 
 if(WITH_FORTRAN_API OR WITH_FORTRAN08_API)
 
-    set(fortran-sources
+    set(f90safe-fortran-sources
         "chimesFF/api/chimescalc_F.f90"
         "serial_interface/api/chimescalc_serial_F.f90"
+    )
+
+    set(fortran-sources
+        ${f90safe-fortran-sources}
     )
 
     # Optional, as ancient Fortran compilers may have difficulties with it
@@ -98,6 +191,50 @@ if(WITH_FORTRAN_API OR WITH_FORTRAN08_API)
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     )
     install(DIRECTORY "${moddir}/" DESTINATION "${INSTALL_MODULEDIR}")
+    
+    ############################################################
+   # Executables for Fortran (90/08)
+   ############################################################
+
+    
+    add_executable(fortran_wrapper-direct_interface ${f90safe-fortran-sources} ${c-sources} chimesFF/examples/fortran/main.F90)
+    target_link_libraries     (fortran_wrapper-direct_interface ChimesCalc ChimesCalc_Fortran)
+    target_compile_features   (fortran_wrapper-direct_interface PRIVATE cxx_std_11)
+    target_compile_options    (fortran_wrapper-direct_interface PRIVATE -O3)
+    target_compile_options    (fortran_wrapper-direct_interface PRIVATE -fPIC)
+    target_compile_options    (fortran_wrapper-direct_interface PRIVATE -std=f2003)
+    target_compile_definitions(fortran_wrapper-direct_interface PRIVATE "DEBUG=${DEBUG}")
+
+    IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+    	    install(TARGETS fortran_wrapper-direct_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/fortran/ OPTIONAL)
+    ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+
+
+    add_executable(fortran_wrapper-serial_interface ${f90safe-fortran-sources} ${c-sources} serial_interface/examples/fortran/main.F90)
+    target_link_libraries     (fortran_wrapper-serial_interface ChimesCalc ChimesCalc_Fortran)
+    target_compile_features   (fortran_wrapper-serial_interface PRIVATE cxx_std_11)
+    target_compile_options    (fortran_wrapper-serial_interface PRIVATE -O3)
+    target_compile_options    (fortran_wrapper-serial_interface PRIVATE -fPIC)
+    target_compile_options    (fortran_wrapper-serial_interface PRIVATE -std=f2003)
+    target_compile_definitions(fortran_wrapper-serial_interface PRIVATE "DEBUG=${DEBUG}")
+
+    IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+    	    install(TARGETS fortran_wrapper-direct_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/fortran/ OPTIONAL)
+    ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+    
+    if(WITH_FORTRAN08_API) # Optional, as ancient Fortran compilers may have difficulties with it
+        add_executable(fortran08_wrapper-serial_interface ${fortran-sources} ${c-sources} serial_interface/examples/fortran08/main.F90)
+        target_link_libraries	  (fortran08_wrapper-serial_interface ChimesCalc ChimesCalc_Fortran)
+	target_compile_features   (fortran08_wrapper-serial_interface PRIVATE cxx_std_11)
+	target_compile_options    (fortran08_wrapper-serial_interface PRIVATE -O3)
+	target_compile_options    (fortran08_wrapper-serial_interface PRIVATE -fPIC)
+	target_compile_options    (fortran08_wrapper-serial_interface PRIVATE -std=f2008)
+	target_compile_definitions(fortran08_wrapper-serial_interface PRIVATE "DEBUG=${DEBUG}")
+
+	IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+	       install(TARGETS fortran08_wrapper-serial_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/fortran08/ OPTIONAL)
+	ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)     
+    endif()    
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,7 @@ cmake_minimum_required(VERSION 3.13)
 project(ChimesCalc
     VERSION 1.0
     DESCRIPTION "ChIMES calculator: Utilities to compute ChIMES interactions"
-	LANGUAGES CXX C
-)
+  	LANGUAGES CXX C)
 
 string(TOLOWER "${PROJECT_NAME}" PROJECT_NAME_LOWER)
 
@@ -23,6 +22,14 @@ if(WITH_FORTRAN_API OR WITH_FORTRAN08_API)
 endif()
 
 
+# Check whether libm is needed to provide the round() function in C
+include(CheckLibraryExists)
+CHECK_LIBRARY_EXISTS("m" "round" "" NEEDS_LIB_M)
+if(NEEDS_LIB_M)
+    set(LIB_M "m")
+endif()
+
+
 ###############################################################################
 # C++/C library
 ###############################################################################
@@ -31,79 +38,77 @@ set(c-sources
     "chimesFF/src/chimesFF.cpp"
     "chimesFF/api/chimescalc_C.cpp"
     "serial_interface/src/serial_chimes_interface.cpp"
-    "serial_interface/api/chimescalc_serial_C.cpp"
-)
+    "serial_interface/api/chimescalc_serial_C.cpp")
+
 set(c-includes
     "chimesFF/src/chimesFF.h"
     "chimesFF/api/chimescalc_C.h"
     "serial_interface/src/serial_chimes_interface.h"
-    "serial_interface/api/chimescalc_serial_C.h"
-)
+    "serial_interface/api/chimescalc_serial_C.h")
 
 add_library(ChimesCalc "${c-sources}")
 
 set_target_properties(ChimesCalc
     PROPERTIES
     OUTPUT_NAME "chimescalc"
-    PUBLIC_HEADER "${c-includes}"
-)
+    PUBLIC_HEADER "${c-includes}")
+
 target_include_directories(ChimesCalc PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/api>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/src>
-    $<INSTALL_INTERFACE:${INSTALL_INCLUDEDIR}>
-)
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/api>
+    $<INSTALL_INTERFACE:${INSTALL_INCLUDEDIR}>)
+
 target_compile_definitions(ChimesCalc PRIVATE "DEBUG=${DEBUG}")
 target_compile_features(ChimesCalc PRIVATE cxx_std_11)
 
 install(TARGETS ChimesCalc
     EXPORT ${PROJECT_NAME_LOWER}-targets
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${INSTALL_INCLUDEDIR}"
-)
+    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${INSTALL_INCLUDEDIR}")
 
 
 ############################################################
 # Executables for C/C++
 ############################################################
 
-add_executable(CPP-interface ${c-sources} serial_interface/examples/cpp/main.cpp)
+add_executable(CPP-interface serial_interface/examples/cpp/main.cpp)
 target_link_libraries(CPP-interface ChimesCalc)
 target_compile_features   (CPP-interface PUBLIC cxx_std_11)
-target_compile_options    (CPP-interface PUBLIC -O3)
 target_compile_definitions(CPP-interface PRIVATE "DEBUG=${DEBUG}")
 
 
-IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
-	install(TARGETS CPP-interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/cpp/ OPTIONAL)
-ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+	  install(TARGETS CPP-interface
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/cpp/ OPTIONAL)
+endif()
 
-add_executable(C_wrapper-direct_interface ${c-sources} chimesFF/examples/c/main.c)
-target_link_libraries     (C_wrapper-direct_interface ChimesCalc)
+add_executable(C_wrapper-direct_interface chimesFF/examples/c/main.c)
+target_link_libraries     (C_wrapper-direct_interface ChimesCalc ${LIB_M})
 target_compile_features   (C_wrapper-direct_interface PRIVATE cxx_std_11)
-target_compile_options    (C_wrapper-direct_interface PRIVATE -O3)
 target_compile_definitions(C_wrapper-direct_interface PRIVATE "DEBUG=${DEBUG}")
 
 
-IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
-	install(TARGETS C_wrapper-direct_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/c/ OPTIONAL)
-ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+	  install(TARGETS C_wrapper-direct_interface
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/c/ OPTIONAL)
+endif()
 
 
-add_executable(C_wrapper-serial_interface ${c-sources} serial_interface/examples/c/main.c)
+add_executable(C_wrapper-serial_interface serial_interface/examples/c/main.c)
 target_link_libraries     (C_wrapper-serial_interface ChimesCalc)
-target_include_directories(C_wrapper-serial_interface PRIVATE serial_interface/api/)
 target_compile_features   (C_wrapper-serial_interface PRIVATE cxx_std_11)
-target_compile_options    (C_wrapper-serial_interface PRIVATE -O3)
 target_compile_definitions(C_wrapper-serial_interface PRIVATE "DEBUG=${DEBUG}")
 
-IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
-	install(TARGETS C_wrapper-serial_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/c/ OPTIONAL)
-ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+	  install(TARGETS C_wrapper-serial_interface
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/c/ OPTIONAL)
+endif()
 
 
 ############################################################
-# Executables/libraries for Python 
+# Executables/libraries for Python
 ############################################################
 
 
@@ -113,42 +118,45 @@ ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 add_library(lib-C_wrapper-direct_interface MODULE
     ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/api/chimescalc_C.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/chimesFF.cpp
-)
+    ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/chimesFF.cpp)
 
-set_target_properties     (lib-C_wrapper-direct_interface PROPERTIES PREFIX "") # Prevent CMake from prepending "lib" to libwrapper-C.so
-set_target_properties     (lib-C_wrapper-direct_interface PROPERTIES LINKER_LANGUAGE CXX)  # Tell it which language to use
-target_include_directories(lib-C_wrapper-direct_interface PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/)
-target_include_directories(lib-C_wrapper-direct_interface PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/api/)
+# Prevent CMake from prepending "lib" to libwrapper-C.so
+set_target_properties     (lib-C_wrapper-direct_interface PROPERTIES PREFIX "")
+# Tell it which language to use
+set_target_properties     (lib-C_wrapper-direct_interface PROPERTIES LINKER_LANGUAGE CXX)
+target_include_directories(lib-C_wrapper-direct_interface
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/)
+target_include_directories(lib-C_wrapper-direct_interface
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/api/)
 target_compile_features   (lib-C_wrapper-direct_interface PUBLIC cxx_std_11)
-target_compile_options    (lib-C_wrapper-direct_interface PUBLIC -O3)
-target_compile_options    (lib-C_wrapper-direct_interface PUBLIC -fPIC)
 
-IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
-	install(TARGETS lib-C_wrapper-direct_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/python/ OPTIONAL)
-ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+	  install(TARGETS lib-C_wrapper-direct_interface
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/python/ OPTIONAL)
+endif()
 
 
-add_library(lib-C_wrapper-serial_interface MODULE  
+add_library(lib-C_wrapper-serial_interface MODULE
     ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/api/chimescalc_serial_C.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/src/serial_chimes_interface.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/chimesFF.cpp
-)
+    ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/chimesFF.cpp)
 
-set_target_properties     (lib-C_wrapper-serial_interface PROPERTIES PREFIX "") # Prevent CMake from prepending "lib" to libwrapper-C.so
-set_target_properties     (lib-C_wrapper-serial_interface PROPERTIES LINKER_LANGUAGE CXX)  # Tell it which language to use
-target_include_directories(lib-C_wrapper-serial_interface PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/api/)
-target_include_directories(lib-C_wrapper-serial_interface PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/src/)
-target_include_directories(lib-C_wrapper-serial_interface PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/)
+# Prevent CMake from prepending "lib" to libwrapper-C.so
+set_target_properties     (lib-C_wrapper-serial_interface PROPERTIES PREFIX "")
+# Tell it which language to use
+set_target_properties     (lib-C_wrapper-serial_interface PROPERTIES LINKER_LANGUAGE CXX)
+target_include_directories(lib-C_wrapper-serial_interface
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/api/)
+target_include_directories(lib-C_wrapper-serial_interface
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/src/)
+target_include_directories(lib-C_wrapper-serial_interface
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/)
 target_compile_features   (lib-C_wrapper-serial_interface PUBLIC cxx_std_11)
-target_compile_options    (lib-C_wrapper-serial_interface PUBLIC -O3)
-target_compile_options    (lib-C_wrapper-serial_interface PUBLIC -fPIC)
 
-#install(TARGETS lib-C_wrapper-serial_interface DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/examples/python/)
-IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
-	install(TARGETS lib-C_wrapper-serial_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/python/ OPTIONAL)
-ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-
+if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+	  install(TARGETS lib-C_wrapper-serial_interface
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/python/ OPTIONAL)
+endif()
 
 
 ###############################################################################
@@ -159,18 +167,15 @@ if(WITH_FORTRAN_API OR WITH_FORTRAN08_API)
 
     set(f90safe-fortran-sources
         "chimesFF/api/chimescalc_F.f90"
-        "serial_interface/api/chimescalc_serial_F.f90"
-    )
+        "serial_interface/api/chimescalc_serial_F.f90")
 
     set(fortran-sources
-        ${f90safe-fortran-sources}
-    )
+        ${f90safe-fortran-sources})
 
     # Optional, as ancient Fortran compilers may have difficulties with it
     if(WITH_FORTRAN08_API)
         list(APPEND fortran-sources
-            "serial_interface/api/chimescalc_serial_F08.f90"
-        )
+            "serial_interface/api/chimescalc_serial_F08.f90")
     endif()
 
     add_library(ChimesCalc_Fortran "${fortran-sources}")
@@ -179,62 +184,57 @@ if(WITH_FORTRAN_API OR WITH_FORTRAN08_API)
 
     set(moddir "${CMAKE_CURRENT_BINARY_DIR}/modfiles")
     set_target_properties(ChimesCalc_Fortran PROPERTIES
-        Fortran_MODULE_DIRECTORY "${moddir}"
-    )
+        Fortran_MODULE_DIRECTORY "${moddir}")
+
     target_include_directories(ChimesCalc_Fortran PUBLIC
         $<BUILD_INTERFACE:${moddir}>
-        $<INSTALL_INTERFACE:${INSTALL_MODULEDIR}>
-    )
+        $<INSTALL_INTERFACE:${INSTALL_MODULEDIR}>)
 
     install(TARGETS ChimesCalc_Fortran
         EXPORT ${PROJECT_NAME_LOWER}-targets
-        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    )
-    install(DIRECTORY "${moddir}/" DESTINATION "${INSTALL_MODULEDIR}")
-    
-    ############################################################
-   # Executables for Fortran (90/08)
-   ############################################################
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
-    
-    add_executable(fortran_wrapper-direct_interface ${f90safe-fortran-sources} ${c-sources} chimesFF/examples/fortran/main.F90)
-    target_link_libraries     (fortran_wrapper-direct_interface ChimesCalc ChimesCalc_Fortran)
-    target_compile_features   (fortran_wrapper-direct_interface PRIVATE cxx_std_11)
-    target_compile_options    (fortran_wrapper-direct_interface PRIVATE -O3)
-    target_compile_options    (fortran_wrapper-direct_interface PRIVATE -fPIC)
+    install(DIRECTORY "${moddir}/" DESTINATION "${INSTALL_MODULEDIR}")
+
+
+    ############################################################
+    # Executables for Fortran (90/08)
+    ############################################################
+
+    add_executable(fortran_wrapper-direct_interface chimesFF/examples/fortran/main.F90)
+    target_link_libraries     (fortran_wrapper-direct_interface ChimesCalc_Fortran)
     target_compile_options    (fortran_wrapper-direct_interface PRIVATE -std=f2003)
     target_compile_definitions(fortran_wrapper-direct_interface PRIVATE "DEBUG=${DEBUG}")
 
-    IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
-    	    install(TARGETS fortran_wrapper-direct_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/fortran/ OPTIONAL)
-    ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
+    if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+        install(TARGETS fortran_wrapper-direct_interface
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/fortran/ OPTIONAL)
+    endif()
 
 
-    add_executable(fortran_wrapper-serial_interface ${f90safe-fortran-sources} ${c-sources} serial_interface/examples/fortran/main.F90)
-    target_link_libraries     (fortran_wrapper-serial_interface ChimesCalc ChimesCalc_Fortran)
-    target_compile_features   (fortran_wrapper-serial_interface PRIVATE cxx_std_11)
-    target_compile_options    (fortran_wrapper-serial_interface PRIVATE -O3)
-    target_compile_options    (fortran_wrapper-serial_interface PRIVATE -fPIC)
+    add_executable(fortran_wrapper-serial_interface serial_interface/examples/fortran/main.F90)
+    target_link_libraries     (fortran_wrapper-serial_interface ChimesCalc_Fortran)
     target_compile_options    (fortran_wrapper-serial_interface PRIVATE -std=f2003)
     target_compile_definitions(fortran_wrapper-serial_interface PRIVATE "DEBUG=${DEBUG}")
 
-    IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
-    	    install(TARGETS fortran_wrapper-direct_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/fortran/ OPTIONAL)
-    ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
-    
-    if(WITH_FORTRAN08_API) # Optional, as ancient Fortran compilers may have difficulties with it
-        add_executable(fortran08_wrapper-serial_interface ${fortran-sources} ${c-sources} serial_interface/examples/fortran08/main.F90)
-        target_link_libraries	  (fortran08_wrapper-serial_interface ChimesCalc ChimesCalc_Fortran)
-	target_compile_features   (fortran08_wrapper-serial_interface PRIVATE cxx_std_11)
-	target_compile_options    (fortran08_wrapper-serial_interface PRIVATE -O3)
-	target_compile_options    (fortran08_wrapper-serial_interface PRIVATE -fPIC)
-	target_compile_options    (fortran08_wrapper-serial_interface PRIVATE -std=f2008)
-	target_compile_definitions(fortran08_wrapper-serial_interface PRIVATE "DEBUG=${DEBUG}")
+    if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    	    install(TARGETS fortran_wrapper-direct_interface
+              DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/fortran/ OPTIONAL)
+    endif()
 
-	IF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT) 
-	       install(TARGETS fortran08_wrapper-serial_interface DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/fortran08/ OPTIONAL)
-	ENDIF (NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)     
-    endif()    
+    # Optional, as ancient Fortran compilers may have difficulties with it
+    if(WITH_FORTRAN08_API)
+        add_executable(fortran08_wrapper-serial_interface
+            serial_interface/examples/fortran08/main.F90)
+        target_link_libraries	  (fortran08_wrapper-serial_interface ChimesCalc_Fortran)
+	      target_compile_options    (fortran08_wrapper-serial_interface PRIVATE -std=f2008)
+	      target_compile_definitions(fortran08_wrapper-serial_interface PRIVATE "DEBUG=${DEBUG}")
+
+	      if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+	          install(TARGETS fortran08_wrapper-serial_interface
+                DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/fortran08/ OPTIONAL)
+	      endif()
+    endif()
 
 endif()
 
@@ -248,20 +248,19 @@ install(
     EXPORT ${PROJECT_NAME_LOWER}-targets
     FILE "${PROJECT_NAME_LOWER}-targets.cmake"
     NAMESPACE "${PROJECT_NAME}::"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME_LOWER}"
-)
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME_LOWER}")
+
 configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/export/${PROJECT_NAME_LOWER}-config.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME_LOWER}-config.cmake"
-    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME_LOWER}"
-)
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME_LOWER}")
+
 write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME_LOWER}-config-version.cmake"
     VERSION "${PROJECT_VERSION}"
-    COMPATIBILITY SameMajorVersion
-)
+    COMPATIBILITY SameMajorVersion)
+
 install(
     FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME_LOWER}-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME_LOWER}-config-version.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME_LOWER}"
-)
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME_LOWER}")

--- a/chimesFF/examples/fortran/CMakeLists.txt
+++ b/chimesFF/examples/fortran/CMakeLists.txt
@@ -6,8 +6,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(TestChimes
     DESCRIPTION "Tests the Fortran interface of the ChIMES calculator"
-	LANGUAGES Fortran CXX
-)
+  	LANGUAGES Fortran CXX)
 
 find_package(ChimesCalc REQUIRED)
 add_executable(test_chimescalc "main.F90")

--- a/cmake/ChimesCalc.cmake
+++ b/cmake/ChimesCalc.cmake
@@ -1,0 +1,44 @@
+# Set up build type
+function(chimescalc_setup_build_type)
+
+    set(default_build_type "Release")
+    get_property(_multiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if(_multiConfig)
+        set(CMAKE_CONFIGURATION_TYPES "Debug;Release")
+        message(STATUS "Build type: Multi-Config (build type selected at the build step)")
+    else()
+        if(NOT CMAKE_BUILD_TYPE)
+            message(STATUS "Build type: ${default_build_type} (default single-config)")
+            set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Build type" FORCE)
+            set_property(CACHE CMAKE_BUILD_TYPE PROPERTY HELPSTRING "Choose the type of build")
+            set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
+        else()
+            message(STATUS "Build type: ${CMAKE_BUILD_TYPE} (manually selected single-config)")
+        endif()
+    endif()
+
+endfunction(chimescalc_setup_build_type)
+
+
+# Copy user configured compiler flags into global compiler flags
+macro(chimescalc_setup_compiler_flags)
+
+    if(CMAKE_BUILD_TYPE)
+        set(_buildtypes ${CMAKE_BUILD_TYPE})
+    else()
+        set(_buildtypes ${CMAKE_CONFIGURATION_TYPES})
+    endif()
+    foreach(_buildtype IN LISTS _buildtypes)
+        foreach (lang IN ITEMS CXX C Fortran)
+            string(TOUPPER "${_buildtype}" _buildtype_upper)
+            set(CMAKE_${lang}_FLAGS " ${${lang}_FLAGS}")
+            set(CMAKE_${lang}_FLAGS_${_buildtype_upper} " ${${lang}_FLAGS_${_buildtype_upper}}")
+            message(STATUS "Flags for ${lang}-compiler (build type: ${_buildtype}): "
+                "${CMAKE_${lang}_FLAGS} ${CMAKE_${lang}_FLAGS_${_buildtype_upper}}")
+        endforeach()
+    endforeach()
+    unset(_buildtypes)
+    unset(_buildtype)
+    unset(_buildtype_upper)
+
+endmacro(chimescalc_setup_compiler_flags)

--- a/config.cmake
+++ b/config.cmake
@@ -6,10 +6,10 @@
 set(DEBUG "0" CACHE STRING "Debug level")
 
 # Enable if you want to build a Fortran interface
-option(WITH_FORTRAN_API "Whether the Fortran API should be built" FALSE)
+option(WITH_FORTRAN_API "Whether the Fortran API should be built" TRUE)
 
 # Enable if you want to build a Fortran 2008 style object oriented interface
-option(WITH_FORTRAN08_API "Whether the Fortran 2008 style API should be built" FALSE)
+option(WITH_FORTRAN08_API "Whether the Fortran 2008 style API should be built" TRUE)
 
 # Turn this on, if the libraries should be built as shared libraries
-option(BUILD_SHARED_LIBS "Whether the libraries built should be shared" FALSE)
+option(BUILD_SHARED_LIBS "Whether the libraries built should be shared" TRUE)

--- a/config.cmake
+++ b/config.cmake
@@ -13,3 +13,85 @@ option(WITH_FORTRAN08_API "Whether the Fortran 2008 style API should be built" T
 
 # Turn this on, if the libraries should be built as shared libraries
 option(BUILD_SHARED_LIBS "Whether the libraries built should be shared" TRUE)
+
+
+# C++ compiler dependent config options
+if("GNU" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
+
+    set(CXX_FLAGS "${CMAKE_CXX_FLAGS}"
+        CACHE STRING "Extra flags for the C compiler")
+
+    set(CXX_FLAGS_RELEASE "-O3 -funroll-all-loops"
+        CACHE STRING "C compiler flags for Release build")
+
+    set(CXX_FLAGS_DEBUG "-g -Wall -pedantic -fbounds-check"
+        CACHE STRING "C compiler flags for Debug build")
+
+elseif("Intel" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
+
+    set(CXX_FLAGS "${CMAKE_CXX_FLAGS}"
+        CACHE STRING "Extra flags for the C compiler")
+
+    set(CXX_FLAGS_RELEASE "-O3 -ip"
+        CACHE STRING "C compiler flags for Release build")
+
+    set(CXX_FLAGS_DEBUG "-g -Wall -traceback"
+        CACHE STRING "C compiler flags for Debug build")
+
+endif()
+
+
+# C compiler dependent config options
+if("GNU" STREQUAL "${CMAKE_C_COMPILER_ID}")
+
+    set(C_FLAGS "${CMAKE_C_FLAGS}"
+        CACHE STRING "Extra flags for the C compiler")
+
+    set(C_FLAGS_RELEASE "-O3 -funroll-all-loops"
+        CACHE STRING "C compiler flags for Release build")
+
+    set(C_FLAGS_DEBUG "-g -Wall -pedantic -fbounds-check"
+        CACHE STRING "C compiler flags for Debug build")
+
+elseif("Intel" STREQUAL "${CMAKE_C_COMPILER_ID}")
+
+    set(C_FLAGS "${CMAKE_C_FLAGS}"
+        CACHE STRING "Extra flags for the C compiler")
+
+    set(C_FLAGS_RELEASE "-O3 -ip"
+        CACHE STRING "C compiler flags for Release build")
+
+    set(C_FLAGS_DEBUG "-g -Wall -traceback"
+        CACHE STRING "C compiler flags for Debug build")
+
+endif()
+
+# Compiler detection, so that CMAKE_Fortran_COMPILER_ID is defined below
+if(WITH_FORTRAN_API OR WITH_FORTRAN08_API)
+  enable_language(Fortran)
+endif()
+
+# Fortran compiler dependent config options
+if("GNU" STREQUAL "${CMAKE_Fortran_COMPILER_ID}")
+
+    set(Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -std=f2008"
+        CACHE STRING "Extra flags for the Fortran compiler")
+
+    set(Fortran_FLAGS_RELEASE "-O3 -funroll-all-loops"
+        CACHE STRING "Fortran compiler flags for Release build")
+
+    set(Fortran_FLAGS_DEBUG "-g -Wall -pedantic -fbounds-check"
+        CACHE STRING "Fortran compiler flags for Debug build")
+
+elseif("Intel" STREQUAL "${CMAKE_Fortran_COMPILER_ID}")
+
+    set(Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -stand f08"
+        CACHE STRING "Extra flags for the Fortran compiler")
+
+    set(Fortran_FLAGS_RELEASE "-O3 -ip"
+        CACHE STRING "Fortran compiler flags for Release build")
+
+    set(Fortran_FLAGS_DEBUG "-g -warn all -check -traceback"
+        CACHE STRING "Fortran compiler flags for Debug build")
+
+endif()

--- a/etc/lmp/src/pair_chimes.h
+++ b/etc/lmp/src/pair_chimes.h
@@ -27,7 +27,7 @@ PairStyle(chimesFF,PairCHIMES); // PairStyle(key, class)
 
 #include "pair.h"
 
-#include "chimesFFF.h"
+#include "chimes_FF.h"
 #include <vector>
 
 

--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,9 @@
 # or
 # ./install.sh <debug option (0 or 1)> <install prefix (full path)>
 
+BUILD=`pwd`/build
 DEBUG=${1-0}  # False (0) by default.
-PREFX=${2-""} # Empty by default
+PREFX=${2-$BUILD} # Empty by default
 
 # Clean up previous installation, 
 

--- a/serial_interface/examples/fortran/CMakeLists.txt
+++ b/serial_interface/examples/fortran/CMakeLists.txt
@@ -6,8 +6,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(TestChimes
     DESCRIPTION "Tests the Fortran interface of the ChIMES calculator"
-	LANGUAGES Fortran CXX
-)
+  	LANGUAGES Fortran CXX)
 
 find_package(ChimesCalc REQUIRED)
 add_executable(test_chimescalc "main.F90")

--- a/serial_interface/examples/fortran08/CMakeLists.txt
+++ b/serial_interface/examples/fortran08/CMakeLists.txt
@@ -6,8 +6,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(TestChimes
     DESCRIPTION "Tests the Fortran interface of the ChIMES calculator"
-	LANGUAGES Fortran CXX
-)
+  	LANGUAGES Fortran CXX)
 
 find_package(ChimesCalc REQUIRED)
 add_executable(test_chimescalc "main.F90")

--- a/serial_interface/tests/run_tests.sh
+++ b/serial_interface/tests/run_tests.sh
@@ -44,7 +44,7 @@ API[4]="fortran08"; EXE[4]="fortran08_wrapper-serial_interface" ; XTRA[4]="" #"0
 echo "Running $STYLE tests"
 date
 
-for compile in MAKEFILE # CMAKE
+for compile in MAKEFILE CMAKE
 do
 	echo "Testing compilation type: $compile"
 


### PR DESCRIPTION
## Pull request template

- [ ] Requested `develop` as target branch
- [ ] Attached test suite log file
- [X] Alerted reviewers if edits impact CMake or Makefile files

Implements compiler and build-type dependent user configurable flags.

ALERT: Should only be merged once RKLindsey/chimes_calculator#9 had been merged to main, as it is based on that.

ALERT: It changes the CMake build system. I did not run the test suite, but I did not change any operational code, but only the CMake architecture.

Note: it targets `main` rather than `develop` as rather is much behind `main`. (I guess, the requirement for targeting `develop` is a mistaken remainder from older development strategies...)