### PR TITLE
Bugfixes: (GCC vs Clang compilation support)

### DIFF
--- a/serial_interface/examples/c/main.c
+++ b/serial_interface/examples/c/main.c
@@ -59,7 +59,7 @@ int main (int argc, char **argv)
   set_chimes_serial(small);
   
   printf("Read args:\n");
-  for (int i=1; i<argc; i++)
+  for (i=1; i<argc; i++)
 	  printf("%i %s\n",i, argv[i]);
 
   int rank = 0;

--- a/serial_interface/examples/fortran08/Makefile
+++ b/serial_interface/examples/fortran08/Makefile
@@ -1,5 +1,5 @@
-CXX     = g++ -O3 -std=c++11 -fPIC
-FCC     = gfortran -O3 -fPIC -std=f2008 -cpp # last flag allows processing of C-style pre-processor directives
+CXX     = g++      -std=c++11 -O2 -fPIC      # Using -O2 instead of -O3 due to gcc compilation issues
+FCC     = gfortran -std=f2008 -O2 -fPIC -cpp 
 
 DEBUG   = 1
 
@@ -52,7 +52,7 @@ UNAME := $(shell uname)
 ifeq (${UNAME},Darwin)
 	FCC += -lc++
 else
-	FCC += -stdc++
+	FCC += -lstdc++
 endif
 
 test-F: $(LINKS)


### PR DESCRIPTION
Note: These edits modify the fortran08 serial calculator example Makefile. The previous version compiles on native mac-os configurations (where g++ is just an alias for clang++), but when g++ is used.

[run_tests.log](https://github.com/rk-lindsey/chimes_calculator/files/7739869/run_tests.log)

## Pull request template

- N/A: Requested `develop` as target branch
- [x] Attached test suite log file
- [x] Alerted reviewers if edits impact CMake or Makefile files
