### PR TITLE
Rationalize installation, run tests via ctest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,36 +17,53 @@ jobs:
     - name: Set up environment (Linux)
       if: contains(matrix.os, 'ubuntu')
       run: |
-        echo "ROOTFOLDER=${PWD}" >> $GITHUB_ENV
+        echo "SOURCEDIR=${PWD}" >> $GITHUB_ENV
+        echo "WORKDIR=${PWD}" >> $GITHUB_ENV
         echo "FC=gfortran" >> $GITHUB_ENV
         echo "CC=gcc" >> $GITHUB_ENV
+        echo "CXX=g++" >> $GITHUB_ENV
         sudo apt-get update
         sudo apt-get install cmake ninja-build
 
     - name: Set up environment (OSX)
       if: contains(matrix.os, 'macos')
       run: |
-        echo "ROOTFOLDER=${PWD}" >> $GITHUB_ENV
+        echo "SOURCEDIR=${PWD}" >> $GITHUB_ENV
+        echo "WORKDIR=${PWD}" >> $GITHUB_ENV
         echo "FC=gfortran-9" >> $GITHUB_ENV
         echo "CC=gcc-9" >> $GITHUB_ENV
+        echo "CXX=g++-9" >> $GITHUB_ENV
         brew install ninja
 
     - name: Configure build
-      run: >-
-        cmake -B _build -G Ninja
-        -DCMAKE_INSTALL_PREFIX=${ROOTFOLDER}/_install
-        -DWITH_FORTRAN08_API=1
+      run: |
+        mkdir ${WORKDIR}/_build
+        cd ${WORKDIR}/_build
+        cmake -G Ninja -DCMAKE_INSTALL_PREFIX=${WORKDIR}/_install -DWITH_FORTRAN08_API=1 -DTEST_LABELS="minimal" ${SOURCEDIR}
+        cd -
 
     - name: Build project
       run: |
-        cmake --build _build
+        cd ${WORKDIR}/_build
+        ninja all
+        cd -
+
+    - name: Test project
+      run: |
+        cd ${WORKDIR}/_build
+        ctest
+        cd -
 
     - name: Install project
       run: |
-        cmake --install _build
+        cd ${WORKDIR}/_build
+        ninja install
+        cd -
 
     - name: Run integration test
       run: |
-        CMAKE_PREFIX_PATH=${ROOTFOLDER}/_install cmake -B _build_integtest -G Ninja ${ROOTFOLDER}/serial_interface/examples/fortran08
-        cmake --build _build_integtest
-        LD_LIBRARY_PATH=${ROOTFOLDER}/_install/lib ./_build_integtest/test_chimescalc ${ROOTFOLDER}/serial_interface/tests/force_fields/test_params.CHON.txt serial_interface/tests/configurations/CHON.testfile.000.xyz | grep "Energy (kcal/mol) -7.83714"
+        mkdir ${WORKDIR}/_build_integtest
+        cd ${WORKDIR}/_build_integtest
+        CMAKE_PREFIX_PATH=${WORKDIR}/_install cmake -G Ninja ${SOURCEDIR}/serial_interface/examples/fortran08
+        ninja all
+        LD_LIBRARY_PATH=${WORKDIR}/_install/lib ./test_chimescalc ${SOURCEDIR}/serial_interface/tests/force_fields/test_params.CHON.txt ${SOURCEDIR}/serial_interface/tests/configurations/CHON.testfile.000.xyz | grep "Energy (kcal/mol): -7.83714"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,12 +73,13 @@ install(TARGETS ChimesCalc
 ####################################################################################################
 
 # Main executable installed as chimescalc
-add_executable(chimescalc serial_interface/examples/cpp/main.cpp)
-target_link_libraries(chimescalc ChimesCalc)
-target_compile_features   (chimescalc PUBLIC cxx_std_11)
-target_compile_definitions(chimescalc PRIVATE "DEBUG=${DEBUG}")
+add_executable(ChimesCalcExe serial_interface/examples/cpp/main.cpp)
+set_target_properties(ChimesCalcExe PROPERTIES OUTPUT_NAME "chimescalc")
+target_link_libraries(ChimesCalcExe ChimesCalc)
+target_compile_features   (ChimesCalcExe PUBLIC cxx_std_11)
+target_compile_definitions(ChimesCalcExe PRIVATE "DEBUG=${DEBUG}")
 
-install(TARGETS chimescalc DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS ChimesCalcExe DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Test executables
 add_executable(test_c_direct chimesFF/examples/c/main.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
 
-############################################################
+####################################################################################################
 # General settings
-############################################################
+####################################################################################################
 
 project(ChimesCalc
     VERSION 1.0
@@ -29,9 +29,9 @@ if(NEEDS_LIB_M)
 endif()
 
 
-###############################################################################
-# C++/C library
-###############################################################################
+####################################################################################################
+# Static/shared library
+####################################################################################################
 
 set(c-sources
     "chimesFF/src/chimesFF.cpp"
@@ -65,102 +65,61 @@ target_compile_features(ChimesCalc PRIVATE cxx_std_11)
 install(TARGETS ChimesCalc
     EXPORT ${PROJECT_NAME_LOWER}-targets
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${INSTALL_INCLUDEDIR}")
+    PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDEDIR}")
 
 
-############################################################
+####################################################################################################
 # Executables for C/C++
-############################################################
+####################################################################################################
 
-add_executable(CPP-interface serial_interface/examples/cpp/main.cpp)
-target_link_libraries(CPP-interface ChimesCalc)
-target_compile_features   (CPP-interface PUBLIC cxx_std_11)
-target_compile_definitions(CPP-interface PRIVATE "DEBUG=${DEBUG}")
+# Main executable installed as chimescalc
+add_executable(chimescalc serial_interface/examples/cpp/main.cpp)
+target_link_libraries(chimescalc ChimesCalc)
+target_compile_features   (chimescalc PUBLIC cxx_std_11)
+target_compile_definitions(chimescalc PRIVATE "DEBUG=${DEBUG}")
 
+install(TARGETS chimescalc DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-	  install(TARGETS CPP-interface
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/cpp/ OPTIONAL)
-endif()
+# Test executables
+add_executable(test_c_direct chimesFF/examples/c/main.c)
+target_link_libraries     (test_c_direct ChimesCalc ${LIB_M})
+target_compile_features   (test_c_direct PRIVATE cxx_std_11)
+target_compile_definitions(test_c_direct PRIVATE "DEBUG=${DEBUG}")
 
-add_executable(C_wrapper-direct_interface chimesFF/examples/c/main.c)
-target_link_libraries     (C_wrapper-direct_interface ChimesCalc ${LIB_M})
-target_compile_features   (C_wrapper-direct_interface PRIVATE cxx_std_11)
-target_compile_definitions(C_wrapper-direct_interface PRIVATE "DEBUG=${DEBUG}")
-
-
-if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-	  install(TARGETS C_wrapper-direct_interface
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/c/ OPTIONAL)
-endif()
+add_executable(test_c_serial serial_interface/examples/c/main.c)
+target_link_libraries     (test_c_serial ChimesCalc)
+target_compile_features   (test_c_serial PRIVATE cxx_std_11)
+target_compile_definitions(test_c_serial PRIVATE "DEBUG=${DEBUG}")
 
 
-add_executable(C_wrapper-serial_interface serial_interface/examples/c/main.c)
-target_link_libraries     (C_wrapper-serial_interface ChimesCalc)
-target_compile_features   (C_wrapper-serial_interface PRIVATE cxx_std_11)
-target_compile_definitions(C_wrapper-serial_interface PRIVATE "DEBUG=${DEBUG}")
+####################################################################################################
+# Dynamically loadable library (e.g for Python)
+####################################################################################################
 
-if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-	  install(TARGETS C_wrapper-serial_interface
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/c/ OPTIONAL)
-endif()
+add_library(ChimesCalc_dynamic MODULE "${c-sources}")
 
+set_target_properties(ChimesCalc_dynamic
+    PROPERTIES OUTPUT_NAME "chimescalc_dl")
 
-############################################################
-# Executables/libraries for Python
-############################################################
+target_include_directories(ChimesCalc_dynamic PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/api>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/src>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/api>
+    $<INSTALL_INTERFACE:${INSTALL_INCLUDEDIR}>)
 
+target_compile_definitions(ChimesCalc_dynamic PRIVATE "DEBUG=${DEBUG}")
+target_compile_features(ChimesCalc_dynamic PRIVATE cxx_std_11)
 
-# Shared: .dylib
-# Static: .a
-# Module: .so
-
-add_library(lib-C_wrapper-direct_interface MODULE
-    ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/api/chimescalc_C.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/chimesFF.cpp)
-
-# Prevent CMake from prepending "lib" to libwrapper-C.so
-set_target_properties     (lib-C_wrapper-direct_interface PROPERTIES PREFIX "")
-# Tell it which language to use
-set_target_properties     (lib-C_wrapper-direct_interface PROPERTIES LINKER_LANGUAGE CXX)
-target_include_directories(lib-C_wrapper-direct_interface
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/)
-target_include_directories(lib-C_wrapper-direct_interface
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/api/)
-target_compile_features   (lib-C_wrapper-direct_interface PUBLIC cxx_std_11)
-
-if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-	  install(TARGETS lib-C_wrapper-direct_interface
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/python/ OPTIONAL)
-endif()
+install(TARGETS ChimesCalc_dynamic
+    EXPORT ${PROJECT_NAME_LOWER}-targets
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDEDIR}")
 
 
-add_library(lib-C_wrapper-serial_interface MODULE
-    ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/api/chimescalc_serial_C.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/src/serial_chimes_interface.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/chimesFF.cpp)
-
-# Prevent CMake from prepending "lib" to libwrapper-C.so
-set_target_properties     (lib-C_wrapper-serial_interface PROPERTIES PREFIX "")
-# Tell it which language to use
-set_target_properties     (lib-C_wrapper-serial_interface PROPERTIES LINKER_LANGUAGE CXX)
-target_include_directories(lib-C_wrapper-serial_interface
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/api/)
-target_include_directories(lib-C_wrapper-serial_interface
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/src/)
-target_include_directories(lib-C_wrapper-serial_interface
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/chimesFF/src/)
-target_compile_features   (lib-C_wrapper-serial_interface PUBLIC cxx_std_11)
-
-if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-	  install(TARGETS lib-C_wrapper-serial_interface
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/python/ OPTIONAL)
-endif()
-
-
-###############################################################################
-# Fortran library (separate library as it needs Fortran runtime to be linked)
-###############################################################################
+####################################################################################################
+# Fortran wrappers (not contained in base library as it requires Fortran runtime library)
+####################################################################################################
 
 if(WITH_FORTRAN_API OR WITH_FORTRAN08_API)
 
@@ -196,47 +155,26 @@ if(WITH_FORTRAN_API OR WITH_FORTRAN08_API)
     install(DIRECTORY "${moddir}/" DESTINATION "${INSTALL_MODULEDIR}")
 
 
-    ############################################################
+    ################################################################################################
     # Executables for Fortran (90/08)
-    ############################################################
+    ################################################################################################
 
-    add_executable(fortran_wrapper-direct_interface chimesFF/examples/fortran/main.F90)
-    target_link_libraries     (fortran_wrapper-direct_interface ChimesCalc_Fortran)
-    target_compile_definitions(fortran_wrapper-direct_interface PRIVATE "DEBUG=${DEBUG}")
-
-    if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-        install(TARGETS fortran_wrapper-direct_interface
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/chimesFF/examples/fortran/ OPTIONAL)
-    endif()
-
-
-    add_executable(fortran_wrapper-serial_interface serial_interface/examples/fortran/main.F90)
-    target_link_libraries     (fortran_wrapper-serial_interface ChimesCalc_Fortran)
-    target_compile_definitions(fortran_wrapper-serial_interface PRIVATE "DEBUG=${DEBUG}")
-
-    if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    	    install(TARGETS fortran_wrapper-direct_interface
-              DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/fortran/ OPTIONAL)
-    endif()
+    add_executable(test_fortran_serial serial_interface/examples/fortran/main.F90)
+    target_link_libraries(test_fortran_serial ChimesCalc_Fortran)
+    target_compile_definitions(test_fortran_serial PRIVATE "DEBUG=${DEBUG}")
 
     # Optional, as ancient Fortran compilers may have difficulties with it
     if(WITH_FORTRAN08_API)
-        add_executable(fortran08_wrapper-serial_interface
-            serial_interface/examples/fortran08/main.F90)
-        target_link_libraries	  (fortran08_wrapper-serial_interface ChimesCalc_Fortran)
-	      target_compile_definitions(fortran08_wrapper-serial_interface PRIVATE "DEBUG=${DEBUG}")
-
-	      if(NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-	          install(TARGETS fortran08_wrapper-serial_interface
-                DESTINATION ${CMAKE_INSTALL_PREFIX}/serial_interface/examples/fortran08/ OPTIONAL)
-	      endif()
+        add_executable(test_fortran08_serial serial_interface/examples/fortran08/main.F90)
+        target_link_libraries(test_fortran08_serial ChimesCalc_Fortran)
+	      target_compile_definitions(test_fortran08_serial PRIVATE "DEBUG=${DEBUG}")
     endif()
 
 endif()
 
-###############################################################################
+####################################################################################################
 # Create CMake export file
-###############################################################################
+####################################################################################################
 
 include(CMakePackageConfigHelpers)
 
@@ -260,3 +198,68 @@ install(
     FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME_LOWER}-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME_LOWER}-config-version.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME_LOWER}")
+
+
+####################################################################################################
+# Add regression tests for the various APIs
+####################################################################################################
+
+enable_testing()
+
+set(apis
+    "cpp;${CMAKE_CURRENT_BINARY_DIR}/chimescalc"
+    "c;${CMAKE_CURRENT_BINARY_DIR}/test_c_serial"
+    "fortran;${CMAKE_CURRENT_BINARY_DIR}/test_fortran_serial"
+    "fortran08;${CMAKE_CURRENT_BINARY_DIR}/test_fortran08_serial")
+
+set(_testdir "${CMAKE_CURRENT_SOURCE_DIR}/serial_interface/tests")
+file(STRINGS ${_testdir}/tests _testcases)
+foreach(_testcase IN LISTS _testcases)
+    if("${_testcase}" STREQUAL "")
+        continue()
+    endif()
+    list(GET _testcase 0 _paramfile)
+    string(STRIP "${_paramfile}" _paramfile)
+    list(GET _testcase 1 _geometry)
+    string(STRIP "${_geometry}" _geometry)
+    string(REPLACE "#" "" _geometry_escaped "${_geometry}")
+    list(GET _testcase 2 _configopt)
+    string(STRIP "${_configopt}" _configopt)
+    list(GET _testcase 3 _testlabels)
+    string(STRIP "${_testlabels}" _testlabels)
+
+    set(_add_test False)
+    foreach(_label IN LISTS TEST_LABELS)
+        if("${_testlabels}" MATCHES "${_label}")
+            set(_add_test True)
+            break()
+        endif()
+    endforeach()
+    if(NOT _add_test)
+        continue()
+    endif()
+
+    set(_apis "${apis}")
+    list(LENGTH _apis _apis_length )
+    while(_apis_length GREATER 0)
+        list(POP_FRONT _apis _api_abbrev)
+        list(POP_FRONT _apis _api_executable)
+        #message(STATUS "Test added: ${_api_abbrev}:${_paramfile}:${_geometry_escaped}")
+        list(LENGTH _apis _apis_length)
+
+        add_test(
+            NAME "${_api_abbrev}/${_paramfile}:${_geometry_escaped}"
+            COMMAND
+                ${_testdir}/run_test_case
+                ${_api_executable}
+                ${_paramfile}
+                ${_geometry}
+                ${_configopt}
+                ${CMAKE_CURRENT_BINARY_DIR}/_test/${_api_abbrev}/${_paramfile}:${_geometry_escaped})
+        if("${_api_abbrev}" STREQUAL "py")
+            set_tests_properties("${_api_abbrev}/${_paramfile}:${_geometry_escaped}"
+                PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
+                ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}")
+        endif()
+    endwhile()
+endforeach()

--- a/config.cmake
+++ b/config.cmake
@@ -14,6 +14,10 @@ option(WITH_FORTRAN08_API "Whether the Fortran 2008 style API should be built" T
 # Turn this on, if the libraries should be built as shared libraries
 option(BUILD_SHARED_LIBS "Whether the libraries built should be shared" TRUE)
 
+# Test cases with labels matching the specified regexps will be included as tests in CMake builds
+# (You can still select subsets of the selected tests by name using the -R option of ctest)
+set(TEST_LABELS ".*" CACHE STRING "List of test label regexps to include as test in CMake builds")
+
 
 # C++ compiler dependent config options
 if("GNU" STREQUAL "${CMAKE_CXX_COMPILER_ID}")

--- a/serial_interface/examples/fortran/main.F90
+++ b/serial_interface/examples/fortran/main.F90
@@ -8,10 +8,9 @@
       implicit none
       integer io_num, stat, small
       double precision, parameter :: GPa = 6.9479 ! convert kcal/mol.A^3 to GPa
-      character(C_char), dimension(80) :: c_file
-      character(C_char), dimension(80) :: dummy_var
-      character(80) :: coord_file, param_file
-      CHARACTER ( len = 100 ) :: wq_char
+      character(C_char), dimension(1025) :: c_file
+      character(1024) :: coord_file, param_file
+      CHARACTER ( len = 1024 ) :: wq_char
       integer :: i, j, k, l, natom, ns
       real(C_double) ::   lx, ly, lz
       real(C_double) :: stress(9)
@@ -78,34 +77,33 @@
       energy = 0d0
 
       call f_set_chimes(small)
-      
+
       print*,"fcheck-1"
 
-      c_file = string2Cstring(param_file)
-      call f_init_chimes(c_file,  0) ! last '0' is the rank of the process
-      
+      call f_init_chimes(trim(param_file) // c_null_char,  0) ! last '0' is the rank of the process
+
       print*,"fcheck-2"
-      
+
       stress(:) = 0d0
       do ns = 1, natom
         stringPtr(ns) = c_loc(c_atom(ns))
       enddo
-      
+
       print*,"fcheck-3"
 
       call f_calculate_chimes (natom, xc, yc, zc, stringPtr, ca,  &
       &      cb, cc, energy, fx, fy, fz, stress)
 
       print *, "Success!"
-      print '(A,1X, F0.6)', "Energy (kcal/mol)",energy
-      print *, "Stress tensors (GPa)"
+      print '(A,1X, F0.6)', "Energy (kcal/mol):",energy
+      print *, "Stress tensors (GPa):"
       print '(A,1X, F15.6)', "s_xx: ",stress(1)*GPa
       print '(A,1X, F15.6)', "s_yy: ",stress(5)*GPa
       print '(A,1X, F15.6)', "s_zz: ",stress(9)*GPa
       print '(A,1X, F15.6)', "s_xy: ",stress(2)*GPa
       print '(A,1X, F15.6)', "s_xz: ",stress(3)*GPa
       print '(A,1X, F15.6)', "s_yz: ",stress(6)*GPa
-      print *, "Forces (kcal/mol)"
+      print *, "Forces (kcal/mol/A):"
       do i = 1, natom
          print '(F15.6)',fx(i)
          print '(F15.6)',fy(i)

--- a/serial_interface/examples/fortran08/main.F90
+++ b/serial_interface/examples/fortran08/main.F90
@@ -70,7 +70,7 @@ program test_F08_api
   call chimes%calculate(coords, latvecs, energy, forces, stress)
 
   print *, "Success!"
-  print '(A,1X, F0.6)', "Energy (kcal/mol)", energy
+  print '(A,1X, F0.6)', "Energy (kcal/mol):", energy
   print *, "Stress tensors (GPa)"
   print '(A,1X, F15.6)', "s_xx: ", stress(1, 1) * GPa
   print '(A,1X, F15.6)', "s_yy: ", stress(2, 2) * GPa
@@ -78,7 +78,7 @@ program test_F08_api
   print '(A,1X, F15.6)', "s_xy: ", stress(1, 2) * GPa
   print '(A,1X, F15.6)', "s_xz: ", stress(1, 3) * GPa
   print '(A,1X, F15.6)', "s_yz: ", stress(2, 3) * GPa
-  print *, "Forces (kcal/mol)"
+  print *, "Forces (kcal/mol/A)"
   print '(F15.6)', forces
 
 #if DEBUG==1

--- a/serial_interface/tests/compare_output
+++ b/serial_interface/tests/compare_output
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Compares the output of a ChIMES executable with stored reference data.
+
+Returns with non-zero exit code, if reference and output data do not match.
+
+Note: The script parses the ChIMES output in a very simple minded way. If the output changes, the
+parsing algorithm must be adapted accordingly.
+"""
+
+import re
+import sys
+
+_FLOAT_REGEXP = r"[+-]?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?"
+_FLOAT_PATTERN = re.compile(_FLOAT_REGEXP)
+
+_ENERGY_PATTERN = re.compile(
+    r"^\s*Energy \(kcal/mol\):?\s+(?P<energy>{})\s*$".format(_FLOAT_REGEXP),
+    re.MULTILINE)
+
+_STRESS_PATTERN = re.compile(
+    r"^\s*s_[xyz][xyz]:\s*(?P<stress>{})\s*$".format(_FLOAT_REGEXP),
+    re.MULTILINE)
+
+_FORCES_PATTERN = re.compile(
+    r"^\s*Forces \(kcal/mol/A\):?\s*(?P<forces>(?:\s*{}\s*)+)".format(_FLOAT_REGEXP),
+    re.MULTILINE)
+
+# Absolute tolerance when comparing data
+_ABS_TOLERANCE = 1e-3
+
+
+def main():
+    outfile = sys.argv[1]
+    reffile = sys.argv[2]
+
+    with open(outfile) as fp:
+        outcontent = fp.read()
+    with open(reffile) as fp:
+        refcontent = fp.read()
+
+    outdata = _parse_output(outcontent)
+    refdata = _parse_reference(refcontent)
+    match = _check_error(outdata, refdata)
+    if not match:
+        sys.exit(1)
+
+
+def _parse_output(content):
+    """Parser the ChIMES output for energy, stress tensor and forces"""
+    data = []
+    match = _ENERGY_PATTERN.search(content)
+    data.append(float(match.group("energy")))
+    data += [float(m.group("stress"))
+             for m in _STRESS_PATTERN.finditer(content)]
+    match = _FORCES_PATTERN.search(content)
+    data += [float(s) for s in match.group("forces").split()]
+    return data
+
+
+def _parse_reference(content):
+    """Returns all floats in the content as list."""
+    data = [float(match.group(0)) for match in _FLOAT_PATTERN.finditer(content)]
+    return data
+
+
+def _check_error(outdata, refdata):
+    "Cheks whether two list of float data are within a certain tolerance"""
+
+    if len(outdata) != len(refdata):
+        print("Mismatching data list lengths! Expected: {:d}, obtained {:d}."\
+              .format(len(refdata), len(outdata)))
+        return False
+    match = True
+    for outval, refval in zip(outdata, refdata):
+        if abs(outval - refval) > _ABS_TOLERANCE:
+            match = False
+            print("Mismatching values! Expected {:12.6f}, obtained {:12.6f}."\
+                  .format(refval, outval))
+    return match
+
+
+if __name__ == "__main__":
+    main()

--- a/serial_interface/tests/run_test_case
+++ b/serial_interface/tests/run_test_case
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+SCRIPT_NAME=$(basename $0)
+
+if [ $# -ne 5 ]; then
+  echo "Wrong nr. of parameters" >&2
+  echo "run_test_case BINARY PARAMETERFILE GEOMETRYFILE CONFIGOPT WORKDIR" >&2
+  exit 1
+fi
+
+binary=$1
+parameterfile=$2
+geometryfile=$3
+configopt=$4
+workdir=$5
+
+if [ ! -d ${workdir} ]; then
+  mkdir -p ${workdir}
+fi
+
+cd ${workdir}
+${binary} \
+  ${SCRIPT_DIR}/force_fields/${parameterfile} \
+  ${SCRIPT_DIR}/configurations/${geometryfile} \
+  ${configopt} >& output
+
+${SCRIPT_DIR}/compare_output \
+  output \
+  ${SCRIPT_DIR}/expected_output/${parameterfile}.${geometryfile}.dat

--- a/serial_interface/tests/run_tests.sh
+++ b/serial_interface/tests/run_tests.sh
@@ -44,39 +44,39 @@ API[4]="fortran08"; EXE[4]="fortran08_wrapper-serial_interface" ; XTRA[4]="" #"0
 echo "Running $STYLE tests"
 date
 
-for compile in MAKEFILE CMAKE
+for compile in MAKEFILE
 do
 	echo "Testing compilation type: $compile"
 
 	# Do the compilation
 
 	if [[ $compile == "MAKEFILE" ]]; then
-	
+
 		for i in $API_LIST # Cycle through APIs
 		do
-			cd ../examples/${API[$i]}	
-	
+			cd ../examples/${API[$i]}
+
 			echo "Compiling for API ${API[$i]}"
 			echo ""
 
 			if [[ "${API[$i]}" != "python" ]] ; then
-	
+
 				make all DEBUG=1
 			else
 				make all
 				cp lib-C_wrapper-serial_interface.so ../../tests
 			fi
-			
+
 			cd ../../tests
-			
-		done		
-	
+
+		done
+
 	elif [[ $compile == "CMAKE" ]] ; then
-		
+
 		cd ../../
 		./install.sh 1 $PREFX # Set the debug flag true
-		cp build/lib-C_wrapper-serial_interface.so  serial_interface/tests		
-		cd -  
+		cp build/lib-C_wrapper-serial_interface.so  serial_interface/tests
+		cd -
 
 	else
 		echo "Error: Unknown compilation method $compile"
@@ -84,64 +84,64 @@ do
 		echo "Check logic in run_test.sh"
 		exit 0
 	fi
-	
+
 	# Run the tasks
-		
+
 	for i in $API_LIST # Cycle through APIs
-	do	
-		
+	do
+
 		idx=1
 
 		for ((j=0;j<NO_TESTS;j++))
 		do
 			echo "Working on Test $idx of $NO_TESTS for API ${API[$i]}"
-			
+
 			for ((k=0; k<10; k++))
 			do
 				CFG=${CFGS[$j]}
 				CFG_PREFIX="${CFG%%_#*}_#"
 				CFG_SUFFIX=${CFG##*000}
-				
+
 				CFG=${CFG_PREFIX}00${k}${CFG_SUFFIX}
 
 				if [ ! -f configurations/$CFG ] ; then
 					continue
 				fi
-				
+
 				echo "		...Running $CFG"
-				
+
 				# Run the test
-				
+
 				if [[ "${API[$i]}" != "python" ]] ; then
-				
+
 					if [[ $compile == "CMAKE" ]] ; then
 						../../build/${EXE[$i]} force_fields/${FFS[$j]} configurations/$CFG ${OPTIONS[$j]} > /dev/null
 					else
 						../examples/${API[$i]}/${EXE[$i]} force_fields/${FFS[$j]} configurations/$CFG ${OPTIONS[$j]}  > /dev/null
 					fi
-					
-				else				
-					${PYTH3} ../examples/${API[$i]}/${EXE[$i]} force_fields/${FFS[$j]} configurations/$CFG ${OPTIONS[$j]} ${LOC}/../api 1 > /dev/null					
+
+				else
+					${PYTH3} ../examples/${API[$i]}/${EXE[$i]} force_fields/${FFS[$j]} configurations/$CFG ${OPTIONS[$j]} ${LOC}/../api 1 > /dev/null
 				fi
-				
+
 				# Compare results against expected results (expected_output/${FFS[$j]}.$CFG.dat)
-				
+
 				paste debug.dat expected_output/${FFS[$j]}.$CFG.dat > san.dat
 
 				# Print findings
-				
-				${PYTH3} compare.py san.dat 
+
+				${PYTH3} compare.py san.dat
 
 				if [[ $STYLE == "SHORT" ]] ; then
 					break
 				fi
-				
+
 			done
-			
+
 			echo "	Test $idx of $NO_TESTS for API ${API[$i]} complete"
 
 			let idx=idx+1
-			
+
 		done
 
 	done
@@ -163,5 +163,3 @@ rm -f debug.dat san.dat *.so
 
 cd ../../
 ./uninstall.sh $PREFX
-
-

--- a/serial_interface/tests/tests
+++ b/serial_interface/tests/tests
@@ -1,0 +1,63 @@
+test_params.CHON.txt;  CHON.testfile_#000.xyz;  0;  minimal
+
+published_params.liqC.2b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#000.xyz;  0;  short
+published_params.liqC.2b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#001.xyz;  0;  long
+published_params.liqC.2b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#002.xyz;  0;  long
+published_params.liqC.2b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#003.xyz;  0;  long
+published_params.liqC.2b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#004.xyz;  0;  long
+published_params.liqC.2b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#005.xyz;  0;  long
+published_params.liqC.2b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#006.xyz;  0;  long
+published_params.liqC.2b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#007.xyz;  0;  long
+published_params.liqC.2b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#008.xyz;  0;  long
+published_params.liqC.2b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#009.xyz;  0;  long
+
+published_params.liqC.2+3b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#000.xyz;  0;  short
+published_params.liqC.2+3b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#001.xyz;  0;  long
+published_params.liqC.2+3b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#002.xyz;  0;  long
+published_params.liqC.2+3b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#003.xyz;  0;  long
+published_params.liqC.2+3b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#004.xyz;  0;  long
+published_params.liqC.2+3b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#005.xyz;  0;  long
+published_params.liqC.2+3b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#006.xyz;  0;  long
+published_params.liqC.2+3b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#007.xyz;  0;  long
+published_params.liqC.2+3b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#008.xyz;  0;  long
+published_params.liqC.2+3b.cubic.txt;  liqC.2.5gcc_6000K.OUTCAR_#009.xyz;  0;  long
+
+validated_params.liqCO.2+3b.cubic.txt;  CO.2.5gcc_6500K.OUTCAR_#000.relabel.xyz;  1;  short
+
+published_params.liqCO.2+3b.cubic.txt;  CO.2.5gcc_6500K.OUTCAR_#000.xyz;  1;  short
+published_params.liqCO.2+3b.cubic.txt;  CO.2.5gcc_6500K.OUTCAR_#001.xyz;  1;  long
+published_params.liqCO.2+3b.cubic.txt;  CO.2.5gcc_6500K.OUTCAR_#002.xyz;  1;  long
+published_params.liqCO.2+3b.cubic.txt;  CO.2.5gcc_6500K.OUTCAR_#003.xyz;  1;  long
+published_params.liqCO.2+3b.cubic.txt;  CO.2.5gcc_6500K.OUTCAR_#004.xyz;  1;  long
+published_params.liqCO.2+3b.cubic.txt;  CO.2.5gcc_6500K.OUTCAR_#005.xyz;  1;  long
+published_params.liqCO.2+3b.cubic.txt;  CO.2.5gcc_6500K.OUTCAR_#006.xyz;  1;  long
+published_params.liqCO.2+3b.cubic.txt;  CO.2.5gcc_6500K.OUTCAR_#007.xyz;  1;  long
+published_params.liqCO.2+3b.cubic.txt;  CO.2.5gcc_6500K.OUTCAR_#008.xyz;  1;  long
+published_params.liqCO.2+3b.cubic.txt;  CO.2.5gcc_6500K.OUTCAR_#009.xyz;  1;  long
+
+published_params.liqCO.2+3b.cubic.txt;  CO.2.5gcc_6500K.OUTCAR_#000.scramble.xyz;  1;  short
+
+published_params.liqCO.2+3b.cubic.txt;  CO.2.5gcc_6500K.OUTCAR_#000.translate.xyz;  1;  short
+
+published_params.liqCO.2+3b.cubic.txt;  diam.64_#000.xyz;  1;  short
+
+published_params.liqCO.2+3b.cubic.txt;  diam.16_#000.xyz;  1;  short
+
+published_params.liqCO.2+3b.cubic.txt;  diam.8_#000.xyz;   1;  short
+
+published_params.liqCO.2+3b.cubic.txt;  diam.2_#000.xyz;   1;  short
+
+published_params.HN3.2+3+4b.Tersoff.special.offsets.txt;  HN3.2gcc_3000K.OUTCAR_#000.xyz;  0;  short
+published_params.HN3.2+3+4b.Tersoff.special.offsets.txt;  HN3.2gcc_3000K.OUTCAR_#001.xyz;  0;  long
+published_params.HN3.2+3+4b.Tersoff.special.offsets.txt;  HN3.2gcc_3000K.OUTCAR_#002.xyz;  0;  long
+published_params.HN3.2+3+4b.Tersoff.special.offsets.txt;  HN3.2gcc_3000K.OUTCAR_#003.xyz;  0;  long
+published_params.HN3.2+3+4b.Tersoff.special.offsets.txt;  HN3.2gcc_3000K.OUTCAR_#004.xyz;  0;  long
+published_params.HN3.2+3+4b.Tersoff.special.offsets.txt;  HN3.2gcc_3000K.OUTCAR_#006.xyz;  0;  long
+published_params.HN3.2+3+4b.Tersoff.special.offsets.txt;  HN3.2gcc_3000K.OUTCAR_#007.xyz;  0;  long
+published_params.HN3.2+3+4b.Tersoff.special.offsets.txt;  HN3.2gcc_3000K.OUTCAR_#008.xyz;  0;  long
+published_params.HN3.2+3+4b.Tersoff.special.offsets.txt;  HN3.2gcc_3000K.OUTCAR_#009.xyz;  0;  long
+
+validated_params.TiO2.2+3b.Tersoff.txt;  TiO2.unitcell_arbrot_#000.xyz;  0;  short
+validated_params.TiO2.2+3b.Tersoff.txt;  TiO2.unitcell_arbrot_#001.xyz;  0;  long
+
+published_params.CO2400K.2+3+4b.Tersoff.special.offsets.txt;  CO.9GPa_2400K.OUTCAR_#000.xyz;  1;  short


### PR DESCRIPTION
## Pull request template

- [X] Requested `develop` as target branch
- [ ] ~~Attached test suite log file~~
- [X] Alerted reviewers if edits impact CMake or Makefile files

Rationalizeed installation, added testing via ctest.

* It only writes into the build folder, leaving the source folder unchanged (as it should be :wink:)
* It enables parallel test execution (via `ctest -jN`), each test writes in a different folder
* It reads the stdout of ChIMES (instead of `debug.dat`), so that test also work if `DEBUG=0` is set (as in production binaries)
* It now also builds (and installs) the dynamically loadable library (called `libchimescalc_dl.so`), which can be loaded via `ctypes` in Python.
* It removes the installation of unnecessary testing binaries which are of no interest for ChIMES consumers
* It installs one stand-alone binary (called `chimescalc`).
* The GitHub CI contains now a minimal test of all tested interfaces (cpp, c, fortran, fortran08).

Note: The Python wrapper is not installed and tested during the CMake build, as that would require some further changes possibly  affecting the make based testing procedure. That should be made in a future PR.

ALERT: It changes the CMake framework, but only by extending it in a backwards compatible way.