### PR TITLE
Refactor installation script for generalizability 

### DIFF
--- a/doc/source/etc.rst
+++ b/doc/source/etc.rst
@@ -13,7 +13,11 @@ We are currently working toward ChIMES calculator implementation in `LAMMPS <htt
 Quick start
 ^^^^^^^^^^^^^^^^
 
-Provided a system with a C++11-compatible compiler and an MPI compatible compiler are available, LAMMPS can be downloaded, installed, linked to ChIMES, and compiled all at once by navigating to ``etc/lmp`` and executing ``./install.sh``. Once complete, the installation can be tested by navigating to ``etc/lmp/tests`` and running the example via ``../exe/lmp_mpi_chimes -i in.lammps``.
+Provided a system with a C++11-compatible compiler and an MPI compatible compiler are available, LAMMPS can be downloaded, installed, linked to ChIMES, and compiled all at once by navigating to ``etc/lmp``, adding Intel compilers to your path  and executing ``./install.sh``. Once complete, the installation can be tested by navigating to ``etc/lmp/tests`` and running the example via ``../exe/lmp_mpi_chimes -i in.lammps``. 
+
+The install script will automatically detect whether users are on UM (Greatlakes) or LLNL (Quartz/Borax(o) HPC and handle Intel compiler environment setup automatically. For all other users, note that Intel oneapi compilers (which are now free) can be used to properly configure your enviroment for all Intel capabilities (e.g., icc, mpiicpc, mkl, etc.) - simply locate and execute the setvars.sh script within your Intel installation.
+
+
 
 Compiling
 ^^^^^^^^^^^^^^^^

--- a/etc/lmp/etc/Makefile.mpi_chimes
+++ b/etc/lmp/etc/Makefile.mpi_chimes
@@ -6,19 +6,19 @@ SHELL = /bin/sh
 # compiler/linker settings
 # specify flags and libraries needed for your compiler
 
-CC =		mpicxx
-CCFLAGS =	-O3 -std=c++11 -restrict
-SHFLAGS =	-fPIC
-DEPFLAGS =	-M
+CC         = mpiicpc
+CCFLAGS    = -O3 -std=c++11 -restrict
+SHFLAGS    = -fPIC
+DEPFLAGS   = -M
 
-LINK =		mpicxx
-LINKFLAGS =	-O3  -std=c++11
-LIB = 
-SIZE =		size
+LINK       = mpiicpc
+LINKFLAGS  = -O3  -std=c++11
+LIB        = 
+SIZE       = size
 
-ARCHIVE =	ar
-ARFLAGS =	-rc
-SHLIBFLAGS =	-shared
+ARCHIVE    = ar
+ARFLAGS    = -rc
+SHLIBFLAGS = -shared
 
 # ---------------------------------------------------------------------
 # LAMMPS-specific settings, all OPTIONAL
@@ -28,7 +28,7 @@ SHLIBFLAGS =	-shared
 # LAMMPS ifdef settings
 # see possible settings in Section 3.5 of the manual
 
-LMP_INC =	-DLAMMPS_GZIP -DLAMMPS_MEMALIGN=64  # -DLAMMPS_CXX98
+LMP_INC    = -DLAMMPS_GZIP -DLAMMPS_MEMALIGN=64  # -DLAMMPS_CXX98
 
 # MPI library
 # see discussion in Section 3.4 of the manual
@@ -39,9 +39,10 @@ LMP_INC =	-DLAMMPS_GZIP -DLAMMPS_MEMALIGN=64  # -DLAMMPS_CXX98
 # PATH = path for MPI library
 # LIB = name of MPI library
 
-MPI_INC =       -DMPICH_SKIP_MPICXX -DOMPI_SKIP_MPICXX=1
-MPI_PATH = 
-MPI_LIB =	
+
+MPI_INC     = -DMPICH_SKIP_MPICXX -DOMPI_SKIP_MPICXX=1 -I${I_MPI_ROOT}/include
+MPI_PATH    = -L${I_MPI_ROOT}/lib -L${I_MPI_ROOT}/lib/release
+MPI_LIB     = 
 
 # FFT library
 # see discussion in Section 3.5.2 of manual
@@ -50,9 +51,9 @@ MPI_LIB =
 # PATH = path for FFT library
 # LIB = name of FFT library
 
-FFT_INC =    	
-FFT_PATH = 
-FFT_LIB =	
+FFT_INC     =    	
+FFT_PATH    = 
+FFT_LIB     =	
 
 # JPEG and/or PNG library
 # see discussion in Section 3.5.4 of manual
@@ -61,9 +62,9 @@ FFT_LIB =
 # PATH = path(s) for JPEG library and/or PNG library
 # LIB = name(s) of JPEG library and/or PNG library
 
-JPG_INC =       
-JPG_PATH = 	
-JPG_LIB =	
+JPG_INC     =       
+JPG_PATH    = 	
+JPG_LIB     =	
 
 # ---------------------------------------------------------------------
 # build rules and dependencies

--- a/etc/lmp/install.sh
+++ b/etc/lmp/install.sh
@@ -2,8 +2,9 @@
 
 echo ""
 echo "Note: This install script assumes: "
-echo "1. Availibility of C++ compilers with c++11 support"
-echo "2. Availability of MPI compilers"
+echo "1. Availibility of Intel C++ compilers with c++11 support"
+echo "2. Availability of Intel MPI compilers"
+echo "...Intel oneapi compilers are now freely available"
 echo ""
 
 # Cleanup any previous installation
@@ -15,6 +16,7 @@ echo ""
 
 mkdir -p build/lammps_stable_29Oct2020
 
+
 git clone --depth 1 --branch stable_29Oct2020 https://github.com/lammps/lammps.git build/lammps_stable_29Oct2020
 
 
@@ -25,12 +27,42 @@ cp src/pair_chimes.{h,cpp} 		build/lammps_stable_29Oct2020/src/MANYBODY/
 cp etc/pair.{h,cpp} 			build/lammps_stable_29Oct2020/src
 cp etc/Makefile.mpi_chimes 		build/lammps_stable_29Oct2020/src/MAKE
 
+
+# Determine computing environment and attempt to load module files automatically
+
+lochost=`hostname`
+hosttype=""
+
+if [[ $lochost == *"arc-ts.umich.edu"* ]]; then
+    hosttype=UM-ARC
+elif [[ $lochost == *"arc-ts.umich.edu"* ]]; then
+    hosttype=LLNL-LC
+fi
+
+echo "Found host type: $hosttype"
+
+# Load module files and configure compilers
+# Note: If using intel compilers from after Jan. 2021 (e.g.,) have access to oneapi
+#       this means instead of loading inidividual modules for mpi, mkl, etc, can just execute
+#       load the intel (e.g., icc) module and run the the setvars.sh command, e.g. located at 
+#       /sw/pkgs/arc/intel/2022.1.2/setvars.sh --also avail for free
+
+if [[ "$hosttype" == "LLNL-LC" ]] ; then
+    source modfiles/LLNL-LC.mod
+elif [[ "$hosttype" == "UM-ARC" ]] ; then
+    source modfiles/UM-ARC.mod
+fi
+
+module list
+
+
 # Compile
 
 cd build/lammps_stable_29Oct2020/src
 make yes-manybody
-make mpi_chimes
+make -j 4 mpi_chimes
 cd -
+
 
 # Finish
 
@@ -44,6 +76,3 @@ echo "Generated the following LAMMPS executable with ChIMES support:"
 echo "${loc}/exe/lmp_mpi_chimes"
 echo "See ${loc}/tests for usage examples"
 echo ""
-
-
-

--- a/etc/lmp/install.sh
+++ b/etc/lmp/install.sh
@@ -35,8 +35,11 @@ hosttype=""
 
 if [[ $lochost == *"arc-ts.umich.edu"* ]]; then
     hosttype=UM-ARC
-elif [[ $lochost == *"arc-ts.umich.edu"* ]]; then
+elif [[ $lochost == *"quartz"* ]]; then
     hosttype=LLNL-LC
+else
+    echo "WARNING: Host type ($hosttype) unknown"
+    echo "Be sure to load modules/conifugre compilers by hand."
 fi
 
 echo "Found host type: $hosttype"

--- a/etc/lmp/modfiles/LLNL-LC.mod
+++ b/etc/lmp/modfiles/LLNL-LC.mod
@@ -1,0 +1,3 @@
+module load cmake/3.21.1
+module load intel/18.0.1
+module load impi/2018.0

--- a/etc/lmp/modfiles/UM-ARC.mod
+++ b/etc/lmp/modfiles/UM-ARC.mod
@@ -1,0 +1,3 @@
+module load cmake/3.22.2  
+module load intel/18.0.5
+module load impi/2018.4.274

--- a/install.sh
+++ b/install.sh
@@ -24,8 +24,11 @@ hosttype=""
 
 if [[ $lochost == *"arc-ts.umich.edu"* ]]; then
     hosttype=UM-ARC
-elif [[ $lochost == *"arc-ts.umich.edu"* ]]; then
+elif [[ $lochost == *"quartz"* ]]; then
     hosttype=LLNL-LC
+else
+    echo "WARNING: Host type ($hosttype) unknown"
+    echo "Be sure to load modules/conifugre compilers by hand."
 fi
 
 echo "Found host type: $hosttype"

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,31 @@ PREFX=${2-$BUILD} # Empty by default
 
 ./uninstall.sh $PREFX
 
+
+# Load modules
+
+# Determine computing environment and attempt to load module files automatically
+
+lochost=`hostname`
+hosttype=""
+
+if [[ $lochost == *"arc-ts.umich.edu"* ]]; then
+    hosttype=UM-ARC
+elif [[ $lochost == *"arc-ts.umich.edu"* ]]; then
+    hosttype=LLNL-LC
+fi
+
+echo "Found host type: $hosttype"
+
+if [[ "$hosttype" == "LLNL-LC" ]] ; then
+    source modfiles/LLNL-LC.mod
+elif [[ "$hosttype" == "UM-ARC" ]] ; then
+    source modfiles/UM-ARC.mod
+fi
+
+module list
+
+
 # Move into build directory 
 
 mkdir build

--- a/modfiles/LLNL-LC.mod
+++ b/modfiles/LLNL-LC.mod
@@ -1,0 +1,3 @@
+module load cmake/3.21.1
+module load intel/18.0.1
+module load impi/2018.0

--- a/modfiles/UM-ARC.mod
+++ b/modfiles/UM-ARC.mod
@@ -1,0 +1,3 @@
+module load cmake/3.22.2  
+module load intel/2022.1.2
+module load impi/2021.5.1


### PR DESCRIPTION
Note: no change have been made to source code.

Update install script to automatically detect system type (i.e. LLNL Quartz versus UM HPC). Based on system type, appropriate modules are loaded from ./modfiles (or ./etc/lmp/modfiles, if LAMMPS+ChIMES is being compiled).
