### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        version: [11]
 
     steps:
     - name: Checkout code
@@ -24,15 +25,18 @@ jobs:
         echo "CXX=g++" >> $GITHUB_ENV
         sudo apt-get update
         sudo apt-get install cmake ninja-build
-
+          
+    # Note: xcode version 14.0 (default on macos-latest @ 2022-11-23) fails to link gfortran compiled
+    # code. Therefore, 14.1 is selected below (which seems to be installed.)
     - name: Set up environment (OSX)
       if: contains(matrix.os, 'macos')
       run: |
+        xcversion select 14.1
         echo "SOURCEDIR=${PWD}" >> $GITHUB_ENV
         echo "WORKDIR=${PWD}" >> $GITHUB_ENV
-        echo "FC=gfortran-9" >> $GITHUB_ENV
-        echo "CC=gcc-9" >> $GITHUB_ENV
-        echo "CXX=g++-9" >> $GITHUB_ENV
+        echo "FC=gfortran-${{ matrix.version }}" >> $GITHUB_ENV
+        echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+        echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
         brew install ninja
 
     - name: Configure build


### PR DESCRIPTION
Current CI fails for OSX at the Configure build step with the following error. Solution is borrowed from the dftbplus repo, i.e.: dftbplus/.github/workflows.old/fortran-build.yml: 

Run mkdir ${WORKDIR}/_build

CMake Error at /usr/local/Cellar/cmake/3.25.1/share/cmake/Modules/CMakeDetermineCXXCompiler.cmake:48 (message): 14
  Could not find compiler set in environment variable CXX:


-- Configuring incomplete, errors occurred!
  g++-9.
See also "/Users/runner/work/chimes_calculator/chimes_calculator/_build/CMakeFiles/CMakeOutput.log". 19

Call Stack (most recent call first):
  CMakeLists.txt:7 (project)

CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage 25
CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage 26
Error: Process completed with exit code 1.

## Items to be completed prior to PR review
# Note: If not completed, submit as a draft PR

- [ ] Requested `develop` as target branch
- [ ] Attached test suite log file
- [ ] Alerted reviewers if edits impact CMake or Makefile files
