### PR TITLE
Fix issue #53 (Hot fix)

### DIFF
--- a/chimesFF/api/chimescalc_C.cpp
+++ b/chimesFF/api/chimescalc_C.cpp
@@ -73,6 +73,14 @@ void chimes_read_params(char *param_file) {
   chimes_ptr->read_parameters(param_file);
 }
 
+void chimes_build_pair_int_trip_map() {
+  chimes_ptr->build_pair_int_trip_map();
+}
+
+void chimes_build_pair_int_quad_map() {
+  chimes_ptr->build_pair_int_quad_map();
+}
+
 void chimes_compute_2b_props_fromf90(double *rij, double dr[3], char *type1, char *type2, double force[2][3], double stress[9], double *epot)
 {
 	static char *atype2b_fromf90[2];
@@ -153,6 +161,7 @@ void chimes_compute_2b_props(double rij, double dr[3], char *atype2b[2], double 
 }
 
 void chimes_compute_3b_props(double dr_3b[3], double dist_3b[3][3], char *atype3b[3], double f3b[3][3], double stress[9], double *epot) {
+
   // convert all doubles, etc., from C to type vector for C++
   vector <double> dr_3b_vec(3);
   dr_3b_vec[0] = dr_3b[0];
@@ -190,7 +199,7 @@ void chimes_compute_3b_props(double dr_3b[3], double dist_3b[3][3], char *atype3
   vector<double> force_3b_vec(3*CHDIM, 0.0) ;
   vector<double> stress_vec(9,0.0);
   chimes3BTmp chimes_tmp(chimes_ptr->poly_orders[1]) ;
-  
+
   chimes_ptr->compute_3B(dr_3b_vec, dist_3b_vec, type_3b_vec, force_3b_vec, stress_vec, *epot,
       chimes_tmp) ;
 
@@ -215,6 +224,7 @@ void chimes_compute_3b_props(double dr_3b[3], double dist_3b[3][3], char *atype3
   stress[6] += stress_vec[6];
   stress[7] += stress_vec[7];
   stress[8] += stress_vec[8];
+  
 }
 
 void chimes_compute_4b_props(double dr_4b[6], double dist_4b[6][3], char *atype4b[4], double f4b[4][3], double stress[9], double *epot)

--- a/chimesFF/api/chimescalc_C.h
+++ b/chimesFF/api/chimescalc_C.h
@@ -17,6 +17,8 @@ int get_chimes_4b_order();
 void set_chimes();
 void init_chimes(int rank);
 void chimes_read_params(char *param_file);
+void chimes_build_pair_int_trip_map();
+void chimes_build_pair_int_quad_map();
 void chimes_compute_2b_props(double rij, double dr[3], char *atype2b[2], double force[2][3], double stress[9], double *epot);
 void chimes_compute_3b_props(double dr_3b[3], double dist_3b[3][3], char *atype3b[3], double f3b[3][3], double stress[9], double *epot);
 void chimes_compute_4b_props(double dr_4b[6], double dist_4b[6][3], char *atype4b[4], double f4b[4][3], double stress[9], double *epot);

--- a/chimesFF/api/chimescalc_F.f90
+++ b/chimesFF/api/chimescalc_F.f90
@@ -64,6 +64,14 @@
           implicit none
           character (kind=C_char), dimension(*) :: param_file
         end subroutine f_chimes_read_params
+        
+        subroutine f_chimes_build_pair_int_trip_map() &
+      &   bind (C, name='chimes_build_pair_int_trip_map')
+        end subroutine f_chimes_build_pair_int_trip_map       
+
+        subroutine f_chimes_build_pair_int_quad_map() &
+      &   bind (C, name='chimes_build_pair_int_quad_map')
+        end subroutine f_chimes_build_pair_int_quad_map 
 
         function f_get_chimes_2b_order () result (order2b) &
           bind (C, name='get_chimes_2b_order')

--- a/chimesFF/api/chimescalc_py.py
+++ b/chimesFF/api/chimescalc_py.py
@@ -69,7 +69,13 @@ def read_params(param_file):
 	chimes_wrapper.chimes_read_params(in_param_file)
 	return
 	
+def build_pair_int_trip_map():
+	chimes_wrapper.chimes_build_pair_int_trip_map()
+	return
 	
+def build_pair_int_quad_map():
+	chimes_wrapper.chimes_build_pair_int_quad_map()
+	return	
 def chimes_compute_2b_props(rij, dr, atype2b, force, stress, epot):
 	"""
 	Compute 2-body contributions to force, stress, and energy for a 
@@ -136,7 +142,7 @@ def chimes_compute_3b_props(dr_3b, dist_3b, atype3b, force, stress, epot):
 						  (force[2][0], force[2][1], force[2][2]))
 	in_stress  =  (ctypes.c_double * 9)(stress[0], stress[1], stress[2], stress[3], stress[4], stress[5], stress[6], stress[7], stress[8])
 	in_epot    =   ctypes.c_double(epot)
-	
+
 	chimes_wrapper.chimes_compute_3b_props(
 		in_dr,
 		in_dist,

--- a/chimesFF/examples/c/README
+++ b/chimesFF/examples/c/README
@@ -15,9 +15,9 @@ Compile with:
 	make all
 To test the executable:
 
-./test_wrapper-C <parameter file> <xyz file>
+./C_wrapper-direct_interface <parameter file> <xyz file>
 
-e.g. ./test_wrapper-C ../../../serial_interface/tests/force_fields/published_params.liqC.2b.cubic.txt ../../../serial_interface/tests/configurations/liqC.2.5gcc_6000K.OUTCAR_#000.xyzf
+e.g. ./C_wrapper-direct_interface ../../../serial_interface/tests/force_fields/published_params.liqC.2b.cubic.txt ../../../serial_interface/tests/configurations/liqC.2.5gcc_6000K.OUTCAR_#000.xyzf
 
 
 Note: xyz file must be orthorhombic, must provide lattice vectors in the comment line, e.g. lx 0.0 0.0 0.0 ly 0.0 0.0 0.0 lz, and must not

--- a/chimesFF/examples/c/main.c
+++ b/chimesFF/examples/c/main.c
@@ -59,6 +59,8 @@ int main (int argc, char **argv)
   set_chimes();
   init_chimes(0);
   chimes_read_params(argv[1]);
+  chimes_build_pair_int_trip_map();
+  chimes_build_pair_int_quad_map();
   int order2b, order3b, order4b;
   order2b = get_chimes_2b_order();
   order3b = get_chimes_3b_order();

--- a/chimesFF/examples/cpp/README
+++ b/chimesFF/examples/cpp/README
@@ -11,12 +11,12 @@ an integer defining how many layers of ghost atoms should be used
 self-interaction across the periodic boundary. 
 
 Compile with:
-        make test-CPP
+        make all
 
 To test the executable:
 
-./test-CPP <parameter file> <xyz file> <nlayers>
+./chimescalc <parameter file> <xyz file> <nlayers>
 
-e.g. ./test-CPP ../../../serial_interface/tests/force_fields/published_params.liqC.2b.cubic.txt ../../../serial_interface/tests/configurations/liqC.2.5gcc_6000K.OUTCAR_#000.xyzf 2
+e.g. ./chimescalc ../../../serial_interface/tests/force_fields/published_params.liqC.2b.cubic.txt ../../../serial_interface/tests/configurations/liqC.2.5gcc_6000K.OUTCAR_#000.xyzf 2
 
 Note: xyz file must be orthorhombic and must provide lattice vectors in the comment line, e.g. lx 0.0 0.0 0.0 ly 0.0 0.0 0.0 lz

--- a/chimesFF/examples/fortran/Makefile
+++ b/chimesFF/examples/fortran/Makefile
@@ -16,7 +16,7 @@ chimescalc_C.o : $(CC_WRAPPER_SRC) $(CC_WRAPPER_HDR) $(CHIMESFF_SRC)  $(CHIMESFF
 
 FCC = gfortran -O3 -fPIC -std=f2003
 
-FCC_WRAPPER_SRC=$(FCC_LOC)/../../api/chimescalc_F.F90
+FCC_WRAPPER_SRC=$(FCC_LOC)/../../api/chimescalc_F.f90
 	
 chimescalc_F.o chimescalc.mod : $(FCC_WRAPPER_SRC)
 	$(FCC) -c $(FCC_WRAPPER_SRC) -o chimescalc_F.o

--- a/chimesFF/examples/fortran/README
+++ b/chimesFF/examples/fortran/README
@@ -15,8 +15,8 @@ Compile with:
 
 To test the executable:
 
-./test_wrapper-F <parameter file> <xyz file>
+./chimescalc-test_direct-F <parameter file> <xyz file>
 
-e.g. ./test_wrapper-F ../../../serial_interface/tests/force_fields/published_params.liqC.2b.cubic.txt ../../../serial_interface/tests/configurations/liqC.2.5gcc_6000K.OUTCAR_#000.xyzf
+e.g. ./chimescalc-test_direct-F ../../../serial_interface/tests/force_fields/published_params.liqC.2b.cubic.txt ../../../serial_interface/tests/configurations/liqC.2.5gcc_6000K.OUTCAR_#000.xyzf
 
 Note: xyz file must be orthorhombic and must provide lattice vectors in the comment line, e.g. lx 0.0 0.0 0.0 ly 0.0 0.0 0.0 lz

--- a/chimesFF/examples/fortran/main.F90
+++ b/chimesFF/examples/fortran/main.F90
@@ -80,6 +80,8 @@
       call f_init_chimes(rank)
       c_file = string2Cstring(param_file)
       call  f_chimes_read_params(c_file)
+      call  f_chimes_build_pair_int_trip_map()
+      call  f_chimes_build_pair_int_quad_map()
       order2b=f_get_chimes_2b_order();
       order3b=f_get_chimes_3b_order();
       order4b=f_get_chimes_4b_order();

--- a/chimesFF/examples/python/Makefile
+++ b/chimesFF/examples/python/Makefile
@@ -1,6 +1,6 @@
 CC_LOC = $(realpath .)
 
-CXX=g++ -g  -std=c++11 -fPIC
+CXX=g++ -O3  -std=c++11 -fPIC
 
 CHIMESFF_SRC=$(CC_LOC)/../../src/chimesFF.cpp
 CHIMESFF_HDR=$(CC_LOC)/../../src/chimesFF.h

--- a/chimesFF/examples/python/Makefile
+++ b/chimesFF/examples/python/Makefile
@@ -1,6 +1,6 @@
 CC_LOC = $(realpath .)
 
-CXX=g++ -O3 -std=c++11 -fPIC
+CXX=g++ -g  -std=c++11 -fPIC
 
 CHIMESFF_SRC=$(CC_LOC)/../../src/chimesFF.cpp
 CHIMESFF_HDR=$(CC_LOC)/../../src/chimesFF.h

--- a/chimesFF/examples/python/main.py
+++ b/chimesFF/examples/python/main.py
@@ -47,7 +47,7 @@ def get_dist(lx,ly,lz,xrd,ycrd,zcrd,i,j):
 
 # Initialize the ChIMES calculator
 
-chimescalc_py.chimes_wrapper = chimescalc_py.init_chimes_wrapper("libchimescalc-direct_dl.so")
+chimescalc_py.chimes_wrapper = chimescalc_py.init_chimes_wrapper(os.getcwd() + "/libchimescalc-direct_dl.so")
 chimescalc_py.set_chimes()
 chimescalc_py.init_chimes()
 
@@ -66,7 +66,9 @@ coord_file = sys.argv[2] # coordinate file
 
 # Read the parameters
 
-wrapper_py.read_params(param_file)
+chimescalc_py.read_params(param_file)
+chimescalc_py.build_pair_int_trip_map()
+chimescalc_py.build_pair_int_quad_map()
 
 # Read the coordinates, set up the force, stress, and energy vars
 
@@ -129,7 +131,7 @@ for i in range(natoms):
 
 		forces[i][0] = tmp_force[0][0]; forces[i][1] = tmp_force[0][1]; forces[i][2] = tmp_force[0][2]
 		forces[j][0] = tmp_force[1][0]; forces[j][1] = tmp_force[1][1]; forces[j][2] = tmp_force[1][2]
-			
+        
 		if (order_3b > 0) or (order_4b> 0):
 
 			for k in range(j+1,natoms):
@@ -153,7 +155,7 @@ for i in range(natoms):
 				forces[i][0] = tmp_force[0][0]; forces[i][1] = tmp_force[0][1]; forces[i][2] = tmp_force[0][2]
 				forces[j][0] = tmp_force[1][0]; forces[j][1] = tmp_force[1][1]; forces[j][2] = tmp_force[1][2]
 				forces[k][0] = tmp_force[2][0]; forces[k][1] = tmp_force[2][1]; forces[k][2] = tmp_force[2][2]
-				
+
 				if dist_ik >= maxcut_4b:
 					continue
 				if dist_jk >= maxcut_4b:

--- a/chimesFF/src/chimesFF.cpp
+++ b/chimesFF/src/chimesFF.cpp
@@ -1562,23 +1562,23 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
     }
 #endif
 
-
     int type_idx =  typ_idxs[0]*natmtyps*natmtyps + typ_idxs[1]*natmtyps + typ_idxs[2] ;
     int tripidx = atom_int_trip_map[type_idx];
 
     if(tripidx < 0)    // Skipping an excluded interaction
         return;
-    
+        
     // Check whether cutoffs are within allowed ranges
     vector<int> & mapped_pair_idx = pair_int_trip_map[type_idx] ;
-        
+
+   
     if (dx[0] >= chimes_3b_cutoff[ tripidx ][1][mapped_pair_idx[0]])    // ij
         return;    
     if (dx[1] >= chimes_3b_cutoff[ tripidx ][1][mapped_pair_idx[1]])    // ik
         return;    
     if (dx[2] >= chimes_3b_cutoff[ tripidx ][1][mapped_pair_idx[2]])    // jk
         return;    
-    
+     
     // At this point, all distances are within allowed ranges. We can now proceed to the force/stress/energy calculation
 
 #ifdef USE_DISTANCE_TENSOR  
@@ -1586,6 +1586,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
     double dr2[CHDIM*CHDIM*npairs*npairs] ;
     init_distance_tensor(dr2, dr, npairs) ;
 #endif
+
 
     // Set up the polynomials
 
@@ -1611,7 +1612,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
     double coeff;
     int powers[npairs] ;
     double force_scalar[npairs] ;
-    
+
     for(int coeffs=0; coeffs<ncoeffs_3b[tripidx]; coeffs++)
     {
         coeff = chimes_3b_params[tripidx][coeffs];
@@ -1710,7 +1711,7 @@ void chimesFF::compute_3B(const vector<double> & dx, const vector<double> & dr, 
         stress[5] -= force_scalar[2]  * dr[2*CHDIM+2] * dr[2*CHDIM+2]; // zz tensor component
 #endif        
     }
-
+    
     force_scalar_in[0] = force_scalar[0];
     force_scalar_in[1] = force_scalar[1];
     force_scalar_in[2] = force_scalar[2];


### PR DESCRIPTION
When chimesFF was refactored to be threadsafe for GPU implementation, build_pair_int_trip_maps and build_pair_int_quad_maps were moved, breaking functionality of the chimesFF/examples, which are not tested during test suite runs, since they are not associated with the serial_interface. README files were also updated to reflect new exectuable names.

Fortran example's Makefile has been updated to reflect change in fortran file extensions (i.e., f90 vs F90).

## Items to be completed prior to PR review
# Note: If not completed, submit as a draft PR

- [N/A] Requested `develop` as target branch -- This is a hotfix for issue #53
- [N/A] Attached test suite log file  --> Doesn't impact files probed by test suite
- [x] Alerted reviewers if edits impact CMake or Makefile files
