### PR TITLE
Create .readthedocs.yaml

### DIFF
--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -16,7 +16,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/source/conf.py
+  configuration: doc/source/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references

--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#   - pdf
+#   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#     - requirements: docs/requirements.txt

--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -32,4 +32,4 @@ sphinx:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
-    - requirements: doc/required_python_packages
+    - requirements: doc/.required_python_packages

--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -30,6 +30,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#     - requirements: docs/requirements.txt
+python:
+  install:
+    - requirements: doc/required_python_packages

--- a/doc/.required_python_packages
+++ b/doc/.required_python_packages
@@ -1,0 +1,1 @@
+sphinx_rtd_theme


### PR DESCRIPTION
Necessary for RtD to compile docs and host on website. Requires RtD settings on RtD website to be configured to find this file (non-standard location)

## Items to be completed prior to PR review
# Note: If not completed, submit as a draft PR

- [x] Requested `develop` as target branch
- [N/A] Attached test suite log file
- [N/A] Alerted reviewers if edits impact CMake or Makefile files
